### PR TITLE
chore(vscode): restore broad BIRD file associations

### DIFF
--- a/packages/@birdcc/vscode/package.json
+++ b/packages/@birdcc/vscode/package.json
@@ -35,8 +35,14 @@
   "activationEvents": [
     "onLanguage:bird2",
     "workspaceContains:**/bird.conf",
+    "workspaceContains:**/bird2.conf",
+    "workspaceContains:**/bird3.conf",
+    "workspaceContains:**/*.conf",
     "workspaceContains:**/*.bird",
-    "workspaceContains:**/*.bird2"
+    "workspaceContains:**/*.bird2",
+    "workspaceContains:**/*.bird3",
+    "workspaceContains:**/*.bird2.conf",
+    "workspaceContains:**/*.bird3.conf"
   ],
   "contributes": {
     "languages": [
@@ -47,8 +53,12 @@
           "bird2"
         ],
         "extensions": [
+          ".conf",
           ".bird",
-          ".bird2"
+          ".bird2",
+          ".bird3",
+          ".bird2.conf",
+          ".bird3.conf"
         ],
         "filenames": [
           "bird.conf",


### PR DESCRIPTION
## Summary
- restore broad BIRD file associations for the VS Code extension language mapping
- keep `.conf` association intentionally, as required by maintainer decision
- include explicit activation patterns for `.conf`, `.bird`, `.bird2`, `.bird3`, `.bird2.conf`, and `.bird3.conf`

## Details
Updated `packages/@birdcc/vscode/package.json`:
- `contributes.languages[0].extensions` now includes:
  - `.conf`
  - `.bird`
  - `.bird2`
  - `.bird3`
  - `.bird2.conf`
  - `.bird3.conf`
- `activationEvents` expanded with matching workspace patterns

## Validation
- `pnpm --filter @birdcc/vscode typecheck`
- `pnpm --filter @birdcc/vscode build`
- `pnpm --filter @birdcc/vscode lint`
- `pnpm --filter @birdcc/vscode format`
