### PR TITLE
feat(vscode): implement phase-2 core lsp lifecycle and config module

### DIFF
--- a/packages/@birdcc/vscode/package.json
+++ b/packages/@birdcc/vscode/package.json
@@ -70,6 +70,12 @@
     "configuration": {
       "title": "BIRD2 LSP",
       "properties": {
+        "bird2-lsp.enabled": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Enable BIRD2 language server client.",
+          "scope": "resource"
+        },
         "bird2-lsp.serverPath": {
           "markdownDescription": "Path to the birdcc language server executable.",
           "oneOf": [
@@ -89,6 +95,29 @@
             "--stdio"
           ],
           "scope": "machine-overridable"
+        },
+        "bird2-lsp.trace.server": {
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "markdownDescription": "Trace level for language client and server communication.",
+          "scope": "machine-overridable"
+        },
+        "bird2-lsp.hiddenErrors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "textDocument/definition",
+            "textDocument/references"
+          ],
+          "markdownDescription": "LSP request methods to suppress from noisy failure popups.",
+          "scope": "resource"
         },
         "bird2-lsp.validation.enabled": {
           "type": "boolean",
@@ -122,6 +151,7 @@
     }
   },
   "dependencies": {
+    "vscode-languageclient": "^9.0.1",
     "zod": "^4.1.11"
   },
   "devDependencies": {

--- a/packages/@birdcc/vscode/src/client/client.ts
+++ b/packages/@birdcc/vscode/src/client/client.ts
@@ -1,0 +1,67 @@
+import type { OutputChannel } from "vscode";
+import {
+  LanguageClient,
+  RevealOutputChannelOn,
+  Trace,
+  type LanguageClientOptions,
+  type ServerOptions,
+} from "vscode-languageclient/node.js";
+
+import {
+  CONFIG_SECTION,
+  EXTENSION_ID,
+  EXTENSION_NAME,
+  LANGUAGE_ID,
+} from "../constants.js";
+import type { ExtensionConfiguration } from "../types.js";
+
+const toServerCommand = (serverPath: ExtensionConfiguration["serverPath"]) => {
+  if (Array.isArray(serverPath)) {
+    const [command, ...args] = serverPath;
+    return { command, args };
+  }
+
+  return { command: serverPath, args: [] as string[] };
+};
+
+const toTraceLevel = (traceServer: ExtensionConfiguration["traceServer"]) => {
+  switch (traceServer) {
+    case "messages":
+      return Trace.Messages;
+    case "verbose":
+      return Trace.Verbose;
+    default:
+      return Trace.Off;
+  }
+};
+
+export const createLanguageClient = (
+  configuration: ExtensionConfiguration,
+  outputChannel: OutputChannel,
+): LanguageClient => {
+  const serverCommand = toServerCommand(configuration.serverPath);
+  const serverOptions: ServerOptions = {
+    command: serverCommand.command,
+    args: serverCommand.args,
+  };
+
+  const clientOptions: LanguageClientOptions = {
+    documentSelector: [{ language: LANGUAGE_ID, scheme: "file" }],
+    outputChannel,
+    revealOutputChannelOn: RevealOutputChannelOn.Never,
+    synchronize: {
+      configurationSection: [CONFIG_SECTION],
+    },
+  };
+
+  const client = new LanguageClient(
+    EXTENSION_ID,
+    EXTENSION_NAME,
+    serverOptions,
+    clientOptions,
+  );
+
+  client.setTrace(toTraceLevel(configuration.traceServer));
+
+  return client;
+};

--- a/packages/@birdcc/vscode/src/client/errors.ts
+++ b/packages/@birdcc/vscode/src/client/errors.ts
@@ -1,0 +1,4 @@
+export const shouldSuppressLspMethod = (
+  method: string,
+  hiddenErrors: readonly string[],
+): boolean => hiddenErrors.includes(method);

--- a/packages/@birdcc/vscode/src/client/index.ts
+++ b/packages/@birdcc/vscode/src/client/index.ts
@@ -1,0 +1,6 @@
+export { createLanguageClient } from "./client.js";
+export {
+  createBirdClientLifecycle,
+  type BirdClientLifecycle,
+  type ClientLifecycleState,
+} from "./lifecycle.js";

--- a/packages/@birdcc/vscode/src/client/lifecycle.ts
+++ b/packages/@birdcc/vscode/src/client/lifecycle.ts
@@ -1,0 +1,117 @@
+import type { OutputChannel } from "vscode";
+import type { LanguageClient } from "vscode-languageclient/node.js";
+
+import type { ExtensionConfiguration } from "../types.js";
+import { createLanguageClient } from "./client.js";
+
+export type ClientLifecycleState =
+  | "idle"
+  | "starting"
+  | "running"
+  | "stopping"
+  | "error";
+
+export interface BirdClientLifecycle {
+  readonly state: ClientLifecycleState;
+  start: (configuration: ExtensionConfiguration) => Promise<void>;
+  stop: () => Promise<void>;
+  restart: (configuration: ExtensionConfiguration) => Promise<void>;
+  dispose: () => Promise<void>;
+}
+
+export const createBirdClientLifecycle = (
+  outputChannel: OutputChannel,
+): BirdClientLifecycle => {
+  let state: ClientLifecycleState = "idle";
+  let activeClient: LanguageClient | undefined;
+  let activeOperation: Promise<void> | undefined;
+
+  const runExclusive = async (operation: () => Promise<void>) => {
+    while (activeOperation) {
+      await activeOperation;
+    }
+
+    const operationPromise = operation();
+    activeOperation = operationPromise;
+    try {
+      await operationPromise;
+    } finally {
+      activeOperation = undefined;
+    }
+  };
+
+  const start = async (configuration: ExtensionConfiguration): Promise<void> =>
+    runExclusive(async () => {
+      if (state === "running") {
+        return;
+      }
+
+      state = "starting";
+      outputChannel.appendLine("[bird2-lsp] starting language client");
+
+      try {
+        activeClient = createLanguageClient(configuration, outputChannel);
+        await activeClient.start();
+        state = "running";
+        outputChannel.appendLine("[bird2-lsp] language client started");
+      } catch (error) {
+        state = "error";
+        activeClient = undefined;
+        outputChannel.appendLine(
+          `[bird2-lsp] failed to start language client: ${String(error)}`,
+        );
+        throw error;
+      }
+    });
+
+  const stop = async (): Promise<void> =>
+    runExclusive(async () => {
+      if (!activeClient) {
+        state = "idle";
+        return;
+      }
+
+      state = "stopping";
+      outputChannel.appendLine("[bird2-lsp] stopping language client");
+
+      try {
+        await activeClient.stop();
+      } finally {
+        activeClient = undefined;
+        state = "idle";
+        outputChannel.appendLine("[bird2-lsp] language client stopped");
+      }
+    });
+
+  const restart = async (
+    configuration: ExtensionConfiguration,
+  ): Promise<void> =>
+    runExclusive(async () => {
+      if (activeClient) {
+        state = "stopping";
+        outputChannel.appendLine("[bird2-lsp] restarting language client");
+        await activeClient.stop();
+      }
+
+      state = "starting";
+      activeClient = createLanguageClient(configuration, outputChannel);
+      await activeClient.start();
+      state = "running";
+      outputChannel.appendLine("[bird2-lsp] language client restarted");
+    });
+
+  const dispose = async (): Promise<void> => {
+    await stop();
+    outputChannel.dispose();
+  };
+
+  return {
+    get state() {
+      return state;
+    },
+    start,
+    stop,
+    restart,
+    dispose,
+  };
+};

--- a/packages/@birdcc/vscode/src/config/configuration.ts
+++ b/packages/@birdcc/vscode/src/config/configuration.ts
@@ -1,0 +1,130 @@
+import {
+  EventEmitter,
+  type ConfigurationChangeEvent,
+  type Disposable,
+  workspace,
+} from "vscode";
+
+import {
+  CONFIG_SECTION,
+  DEFAULT_FORMATTER_ENGINE,
+  DEFAULT_FORMATTER_SAFE_MODE,
+  DEFAULT_HIDDEN_ERRORS,
+  DEFAULT_LSP_ENABLED,
+  DEFAULT_SERVER_PATH,
+  DEFAULT_TRACE_SERVER,
+  DEFAULT_VALIDATION_COMMAND,
+  RESTART_REQUIRED_CONFIGURATION_PATHS,
+} from "../constants.js";
+import {
+  defaultExtensionConfiguration,
+  parseExtensionConfiguration,
+  type ExtensionConfiguration,
+} from "../types.js";
+
+export type ConfigurationChangeReason = "initial-load" | "workspace-change";
+
+export interface ExtensionConfigurationChange {
+  readonly previous: ExtensionConfiguration;
+  readonly current: ExtensionConfiguration;
+  readonly changedPaths: readonly string[];
+  readonly requiresRestart: boolean;
+  readonly reason: ConfigurationChangeReason;
+}
+
+export interface ExtensionConfigurationManager {
+  readonly snapshot: ExtensionConfiguration;
+  refreshFromWorkspace: (
+    reason: ConfigurationChangeReason,
+  ) => ExtensionConfigurationChange;
+  onDidChange: (
+    listener: (event: ExtensionConfigurationChange) => void,
+  ) => Disposable;
+  didSectionChange: (event: ConfigurationChangeEvent) => boolean;
+  dispose: () => void;
+}
+
+const areValuesEqual = (left: unknown, right: unknown): boolean =>
+  JSON.stringify(left) === JSON.stringify(right);
+
+const readWorkspaceConfiguration = (): ExtensionConfiguration => {
+  const config = workspace.getConfiguration(CONFIG_SECTION);
+
+  return parseExtensionConfiguration({
+    enabled: config.get("enabled", DEFAULT_LSP_ENABLED),
+    serverPath: config.get("serverPath", [...DEFAULT_SERVER_PATH]),
+    traceServer: config.get("trace.server", DEFAULT_TRACE_SERVER),
+    hiddenErrors: config.get("hiddenErrors", [...DEFAULT_HIDDEN_ERRORS]),
+    validationEnabled: config.get("validation.enabled", true),
+    validationCommand: config.get(
+      "validation.command",
+      DEFAULT_VALIDATION_COMMAND,
+    ),
+    formatterEngine: config.get("formatter.engine", DEFAULT_FORMATTER_ENGINE),
+    formatterSafeMode: config.get(
+      "formatter.safeMode",
+      DEFAULT_FORMATTER_SAFE_MODE,
+    ),
+  });
+};
+
+const diffConfiguration = (
+  previous: ExtensionConfiguration,
+  current: ExtensionConfiguration,
+): readonly string[] =>
+  (Object.keys(previous) as Array<keyof ExtensionConfiguration>)
+    .filter((key) => !areValuesEqual(previous[key], current[key]))
+    .map((key) => String(key));
+
+const shouldRestart = (changedPaths: readonly string[]): boolean =>
+  changedPaths.some((path) =>
+    RESTART_REQUIRED_CONFIGURATION_PATHS.includes(
+      path as (typeof RESTART_REQUIRED_CONFIGURATION_PATHS)[number],
+    ),
+  );
+
+export const createConfigurationManager = (): ExtensionConfigurationManager => {
+  let snapshot = defaultExtensionConfiguration;
+  const emitter = new EventEmitter<ExtensionConfigurationChange>();
+
+  const refreshFromWorkspace = (
+    reason: ConfigurationChangeReason,
+  ): ExtensionConfigurationChange => {
+    const previous = snapshot;
+    const current = readWorkspaceConfiguration();
+    const changedPaths = diffConfiguration(previous, current);
+
+    snapshot = current;
+
+    const event: ExtensionConfigurationChange = {
+      previous,
+      current,
+      changedPaths,
+      requiresRestart: shouldRestart(changedPaths),
+      reason,
+    };
+
+    if (changedPaths.length > 0) {
+      emitter.fire(event);
+    }
+
+    return event;
+  };
+
+  const didSectionChange = (event: ConfigurationChangeEvent): boolean =>
+    event.affectsConfiguration(CONFIG_SECTION);
+
+  const dispose = (): void => {
+    emitter.dispose();
+  };
+
+  return {
+    get snapshot() {
+      return snapshot;
+    },
+    refreshFromWorkspace,
+    onDidChange: emitter.event,
+    didSectionChange,
+    dispose,
+  };
+};

--- a/packages/@birdcc/vscode/src/config/index.ts
+++ b/packages/@birdcc/vscode/src/config/index.ts
@@ -1,0 +1,5 @@
+export {
+  createConfigurationManager,
+  type ExtensionConfigurationChange,
+  type ExtensionConfigurationManager,
+} from "./configuration.js";

--- a/packages/@birdcc/vscode/src/constants.ts
+++ b/packages/@birdcc/vscode/src/constants.ts
@@ -5,7 +5,20 @@ export const CONFIG_SECTION = "bird2-lsp";
 export const LANGUAGE_ID = "bird2";
 export const LANGUAGE_SCOPE = "source.bird2";
 
+export const DEFAULT_LSP_ENABLED = true;
 export const DEFAULT_SERVER_PATH = ["birdcc", "lsp", "--stdio"] as const;
+export const DEFAULT_TRACE_SERVER = "off" as const;
+export const DEFAULT_HIDDEN_ERRORS = [
+  "textDocument/definition",
+  "textDocument/references",
+] as const;
 export const DEFAULT_VALIDATION_COMMAND = "bird -p -c {file}";
 export const DEFAULT_FORMATTER_ENGINE = "dprint" as const;
 export const DEFAULT_FORMATTER_SAFE_MODE = true;
+
+export const RESTART_REQUIRED_CONFIGURATION_PATHS = [
+  "enabled",
+  "serverPath",
+  "trace.server",
+  "hiddenErrors",
+] as const;

--- a/packages/@birdcc/vscode/src/extension.ts
+++ b/packages/@birdcc/vscode/src/extension.ts
@@ -1,53 +1,76 @@
-import { workspace } from "vscode";
+import { window, workspace } from "vscode";
 import type { ExtensionContext } from "vscode";
 
-import {
-  CONFIG_SECTION,
-  DEFAULT_FORMATTER_ENGINE,
-  DEFAULT_FORMATTER_SAFE_MODE,
-  DEFAULT_SERVER_PATH,
-  DEFAULT_VALIDATION_COMMAND,
-} from "./constants.js";
-import {
-  createDefaultRuntimeState,
-  parseExtensionConfiguration,
-} from "./types.js";
+import { createBirdClientLifecycle } from "./client/index.js";
+import { createConfigurationManager } from "./config/index.js";
+import { EXTENSION_NAME } from "./constants.js";
+import { createDefaultRuntimeState } from "./types.js";
 
 export const runtimeState = createDefaultRuntimeState();
 
-const readConfiguration = () => {
-  const config = workspace.getConfiguration(CONFIG_SECTION);
+let deactivateTask: Promise<void> | undefined;
 
-  return parseExtensionConfiguration({
-    serverPath: config.get("serverPath", [...DEFAULT_SERVER_PATH]),
-    validationEnabled: config.get("validation.enabled", true),
-    validationCommand: config.get(
-      "validation.command",
-      DEFAULT_VALIDATION_COMMAND,
-    ),
-    formatterEngine: config.get("formatter.engine", DEFAULT_FORMATTER_ENGINE),
-    formatterSafeMode: config.get(
-      "formatter.safeMode",
-      DEFAULT_FORMATTER_SAFE_MODE,
-    ),
-  });
+const runConfigurationLifecycle = async (
+  change: ReturnType<
+    ReturnType<typeof createConfigurationManager>["refreshFromWorkspace"]
+  >,
+  lifecycle: ReturnType<typeof createBirdClientLifecycle>,
+): Promise<void> => {
+  runtimeState.configuration = change.current;
+
+  if (!change.current.enabled) {
+    await lifecycle.stop();
+    return;
+  }
+
+  if (lifecycle.state === "running" && change.requiresRestart) {
+    await lifecycle.restart(change.current);
+    return;
+  }
+
+  if (lifecycle.state !== "running") {
+    await lifecycle.start(change.current);
+  }
 };
 
 export const activate = async (context: ExtensionContext): Promise<void> => {
   runtimeState.activated = true;
-  runtimeState.configuration = readConfiguration();
+  const outputChannel = window.createOutputChannel(EXTENSION_NAME);
+  const configurationManager = createConfigurationManager();
+  const lifecycle = createBirdClientLifecycle(outputChannel);
+
+  const initialChange =
+    configurationManager.refreshFromWorkspace("initial-load");
+  await runConfigurationLifecycle(initialChange, lifecycle);
+
+  context.subscriptions.push(
+    configurationManager.onDidChange((event) => {
+      void runConfigurationLifecycle(event, lifecycle);
+    }),
+  );
 
   context.subscriptions.push(
     workspace.onDidChangeConfiguration((event) => {
-      if (!event.affectsConfiguration(CONFIG_SECTION)) {
+      if (!configurationManager.didSectionChange(event)) {
         return;
       }
 
-      runtimeState.configuration = readConfiguration();
+      configurationManager.refreshFromWorkspace("workspace-change");
     }),
   );
+
+  context.subscriptions.push({
+    dispose: () => {
+      configurationManager.dispose();
+      deactivateTask = lifecycle.dispose();
+    },
+  });
 };
 
 export const deactivate = async (): Promise<void> => {
   runtimeState.activated = false;
+  if (deactivateTask) {
+    await deactivateTask;
+    deactivateTask = undefined;
+  }
 };

--- a/packages/@birdcc/vscode/src/index.ts
+++ b/packages/@birdcc/vscode/src/index.ts
@@ -1,9 +1,12 @@
 export { activate, deactivate, runtimeState } from "./extension.js";
 export {
   CONFIG_SECTION,
+  DEFAULT_HIDDEN_ERRORS,
+  DEFAULT_LSP_ENABLED,
   DEFAULT_FORMATTER_ENGINE,
   DEFAULT_FORMATTER_SAFE_MODE,
   DEFAULT_SERVER_PATH,
+  DEFAULT_TRACE_SERVER,
   DEFAULT_VALIDATION_COMMAND,
   EXTENSION_ID,
   EXTENSION_NAME,
@@ -16,9 +19,22 @@ export {
   extensionConfigurationSchema,
   formatterEngineSchema,
   parseExtensionConfiguration,
+  traceServerSchema,
 } from "./types.js";
 export type {
   ExtensionConfiguration,
   ExtensionRuntimeState,
   FormatterEngine,
+  TraceServer,
 } from "./types.js";
+export {
+  createConfigurationManager,
+  type ExtensionConfigurationChange,
+  type ExtensionConfigurationManager,
+} from "./config/index.js";
+export {
+  createBirdClientLifecycle,
+  createLanguageClient,
+  type BirdClientLifecycle,
+  type ClientLifecycleState,
+} from "./client/index.js";

--- a/packages/@birdcc/vscode/src/types.ts
+++ b/packages/@birdcc/vscode/src/types.ts
@@ -1,9 +1,12 @@
 import { z } from "zod";
 
 import {
+  DEFAULT_HIDDEN_ERRORS,
+  DEFAULT_LSP_ENABLED,
   DEFAULT_FORMATTER_ENGINE,
   DEFAULT_FORMATTER_SAFE_MODE,
   DEFAULT_SERVER_PATH,
+  DEFAULT_TRACE_SERVER,
   DEFAULT_VALIDATION_COMMAND,
   EXTENSION_ID,
   EXTENSION_NAME,
@@ -15,9 +18,13 @@ const serverPathSchema = z.union([
 ]);
 
 export const formatterEngineSchema = z.enum(["dprint", "builtin"]);
+export const traceServerSchema = z.enum(["off", "messages", "verbose"]);
 
 export const extensionConfigurationSchema = z.object({
+  enabled: z.boolean(),
   serverPath: serverPathSchema,
+  traceServer: traceServerSchema,
+  hiddenErrors: z.array(z.string().min(1)),
   validationEnabled: z.boolean(),
   validationCommand: z.string().min(1),
   formatterEngine: formatterEngineSchema,
@@ -25,6 +32,7 @@ export const extensionConfigurationSchema = z.object({
 });
 
 export type FormatterEngine = z.infer<typeof formatterEngineSchema>;
+export type TraceServer = z.infer<typeof traceServerSchema>;
 export type ExtensionConfiguration = z.infer<
   typeof extensionConfigurationSchema
 >;
@@ -38,7 +46,10 @@ export interface ExtensionRuntimeState {
 
 export const defaultExtensionConfiguration: ExtensionConfiguration =
   extensionConfigurationSchema.parse({
+    enabled: DEFAULT_LSP_ENABLED,
     serverPath: [...DEFAULT_SERVER_PATH],
+    traceServer: DEFAULT_TRACE_SERVER,
+    hiddenErrors: [...DEFAULT_HIDDEN_ERRORS],
     validationEnabled: true,
     validationCommand: DEFAULT_VALIDATION_COMMAND,
     formatterEngine: DEFAULT_FORMATTER_ENGINE,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
 
   packages/@birdcc/vscode:
     dependencies:
+      vscode-languageclient:
+        specifier: ^9.0.1
+        version: 9.0.1
       zod:
         specifier: ^4.1.11
         version: 4.3.6
@@ -800,9 +803,15 @@ packages:
   axios@1.13.6:
     resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
   brace-expansion@5.0.4:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
@@ -1159,6 +1168,10 @@ packages:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -1441,6 +1454,10 @@ packages:
   vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
+
+  vscode-languageclient@9.0.1:
+    resolution: {integrity: sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==}
+    engines: {vscode: ^1.82.0}
 
   vscode-languageserver-protocol@3.17.5:
     resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
@@ -1975,7 +1992,13 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
+
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.4:
     dependencies:
@@ -2302,6 +2325,10 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.4
 
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.0.2
+
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
@@ -2590,6 +2617,12 @@ snapshots:
       - yaml
 
   vscode-jsonrpc@8.2.0: {}
+
+  vscode-languageclient@9.0.1:
+    dependencies:
+      minimatch: 5.1.9
+      semver: 7.7.4
+      vscode-languageserver-protocol: 3.17.5
 
   vscode-languageserver-protocol@3.17.5:
     dependencies:


### PR DESCRIPTION
Closes #71
Part of #64
Part of #62
Part of #61

## Summary
- add `config` module for typed `bird2-lsp.*` snapshot loading and change detection
- add `client` module for language client creation and lifecycle (`start/stop/restart`)
- wire extension activation/deactivation to configuration-driven lifecycle behavior
- add additional configuration keys: `enabled`, `trace.server`, `hiddenErrors`

## Key Changes
- new files:
  - `src/config/configuration.ts`
  - `src/config/index.ts`
  - `src/client/client.ts`
  - `src/client/lifecycle.ts`
  - `src/client/errors.ts`
  - `src/client/index.ts`
- updated files:
  - `src/extension.ts`
  - `src/types.ts`
  - `src/constants.ts`
  - `src/index.ts`
  - `package.json`
  - `pnpm-lock.yaml`

## Validation
- [x] `pnpm --filter @birdcc/vscode typecheck`
- [x] `pnpm --filter @birdcc/vscode build`
- [x] `pnpm --filter @birdcc/vscode lint`
- [x] `pnpm --filter @birdcc/vscode format`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm format`
