### PR TITLE
feat(vscode): implement phase-2 fallback validator mode

### DIFF
--- a/packages/@birdcc/vscode/package.json
+++ b/packages/@birdcc/vscode/package.json
@@ -131,6 +131,20 @@
           "markdownDescription": "Command template for fallback validation. `{file}` will be replaced with current file path.",
           "scope": "resource"
         },
+        "bird2-lsp.validation.onSave": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Run fallback validation when BIRD2 documents are saved.",
+          "scope": "resource"
+        },
+        "bird2-lsp.validation.timeout": {
+          "type": "number",
+          "default": 30000,
+          "minimum": 1000,
+          "maximum": 120000,
+          "markdownDescription": "Timeout for fallback validation command in milliseconds.",
+          "scope": "resource"
+        },
         "bird2-lsp.formatter.engine": {
           "type": "string",
           "enum": [

--- a/packages/@birdcc/vscode/src/config/configuration.ts
+++ b/packages/@birdcc/vscode/src/config/configuration.ts
@@ -14,6 +14,8 @@ import {
   DEFAULT_SERVER_PATH,
   DEFAULT_TRACE_SERVER,
   DEFAULT_VALIDATION_COMMAND,
+  DEFAULT_VALIDATION_ON_SAVE,
+  DEFAULT_VALIDATION_TIMEOUT_MS,
   RESTART_REQUIRED_CONFIGURATION_PATHS,
 } from "../constants.js";
 import {
@@ -59,6 +61,14 @@ const readWorkspaceConfiguration = (): ExtensionConfiguration => {
     validationCommand: config.get(
       "validation.command",
       DEFAULT_VALIDATION_COMMAND,
+    ),
+    validationOnSave: config.get(
+      "validation.onSave",
+      DEFAULT_VALIDATION_ON_SAVE,
+    ),
+    validationTimeoutMs: config.get(
+      "validation.timeout",
+      DEFAULT_VALIDATION_TIMEOUT_MS,
     ),
     formatterEngine: config.get("formatter.engine", DEFAULT_FORMATTER_ENGINE),
     formatterSafeMode: config.get(

--- a/packages/@birdcc/vscode/src/constants.ts
+++ b/packages/@birdcc/vscode/src/constants.ts
@@ -13,6 +13,8 @@ export const DEFAULT_HIDDEN_ERRORS = [
   "textDocument/references",
 ] as const;
 export const DEFAULT_VALIDATION_COMMAND = "bird -p -c {file}";
+export const DEFAULT_VALIDATION_ON_SAVE = true;
+export const DEFAULT_VALIDATION_TIMEOUT_MS = 30000;
 export const DEFAULT_FORMATTER_ENGINE = "dprint" as const;
 export const DEFAULT_FORMATTER_SAFE_MODE = true;
 

--- a/packages/@birdcc/vscode/src/extension.ts
+++ b/packages/@birdcc/vscode/src/extension.ts
@@ -4,24 +4,43 @@ import type { ExtensionContext } from "vscode";
 import { createBirdClientLifecycle } from "./client/index.js";
 import { createConfigurationManager } from "./config/index.js";
 import { EXTENSION_NAME } from "./constants.js";
+import {
+  createFallbackValidator,
+  type FallbackValidator,
+} from "./fallback/index.js";
 import { createDefaultRuntimeState } from "./types.js";
 
 export const runtimeState = createDefaultRuntimeState();
 
 let deactivateTask: Promise<void> | undefined;
+let fallbackValidator: FallbackValidator | undefined;
+
+const disposeFallbackValidator = (): void => {
+  if (!fallbackValidator) {
+    return;
+  }
+
+  fallbackValidator.dispose();
+  fallbackValidator = undefined;
+};
 
 const runConfigurationLifecycle = async (
   change: ReturnType<
     ReturnType<typeof createConfigurationManager>["refreshFromWorkspace"]
   >,
   lifecycle: ReturnType<typeof createBirdClientLifecycle>,
+  createOrGetFallbackValidator: () => FallbackValidator,
 ): Promise<void> => {
   runtimeState.configuration = change.current;
 
   if (!change.current.enabled) {
     await lifecycle.stop();
+    const validator = createOrGetFallbackValidator();
+    await validator.validateActiveEditor();
     return;
   }
+
+  disposeFallbackValidator();
 
   if (lifecycle.state === "running" && change.requiresRestart) {
     await lifecycle.restart(change.current);
@@ -38,14 +57,33 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
   const outputChannel = window.createOutputChannel(EXTENSION_NAME);
   const configurationManager = createConfigurationManager();
   const lifecycle = createBirdClientLifecycle(outputChannel);
+  const createOrGetFallbackValidator = (): FallbackValidator => {
+    if (!fallbackValidator) {
+      fallbackValidator = createFallbackValidator(
+        () => runtimeState.configuration,
+        outputChannel,
+      );
+      fallbackValidator.activate();
+    }
+
+    return fallbackValidator;
+  };
 
   const initialChange =
     configurationManager.refreshFromWorkspace("initial-load");
-  await runConfigurationLifecycle(initialChange, lifecycle);
+  await runConfigurationLifecycle(
+    initialChange,
+    lifecycle,
+    createOrGetFallbackValidator,
+  );
 
   context.subscriptions.push(
     configurationManager.onDidChange((event) => {
-      void runConfigurationLifecycle(event, lifecycle);
+      void runConfigurationLifecycle(
+        event,
+        lifecycle,
+        createOrGetFallbackValidator,
+      );
     }),
   );
 
@@ -62,6 +100,7 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
   context.subscriptions.push({
     dispose: () => {
       configurationManager.dispose();
+      disposeFallbackValidator();
       deactivateTask = lifecycle.dispose();
     },
   });

--- a/packages/@birdcc/vscode/src/fallback/index.ts
+++ b/packages/@birdcc/vscode/src/fallback/index.ts
@@ -1,0 +1,5 @@
+export { parseBirdValidationOutput } from "./parser.js";
+export {
+  createFallbackValidator,
+  type FallbackValidator,
+} from "./validator.js";

--- a/packages/@birdcc/vscode/src/fallback/parser.ts
+++ b/packages/@birdcc/vscode/src/fallback/parser.ts
@@ -1,0 +1,73 @@
+import {
+  DiagnosticSeverity,
+  Position,
+  Range,
+  Uri,
+  type Diagnostic,
+} from "vscode";
+
+const clampLine = (line: number): number => Math.max(0, line - 1);
+const clampColumn = (column: number | undefined): number =>
+  Math.max(0, (column ?? 1) - 1);
+
+const toDiagnostic = (
+  message: string,
+  line: number,
+  column: number | undefined,
+): Diagnostic => ({
+  message,
+  severity: DiagnosticSeverity.Error,
+  source: "bird -p",
+  range: new Range(
+    new Position(clampLine(line), clampColumn(column)),
+    new Position(clampLine(line), clampColumn(column) + 1),
+  ),
+});
+
+const parseFileLineColumn = (
+  output: string,
+  currentFile: string,
+): Diagnostic[] => {
+  const diagnostics: Diagnostic[] = [];
+  const pattern = /^(.+?):(\d+):(?:(\d+):)?\s*(.+)$/gm;
+
+  for (const match of output.matchAll(pattern)) {
+    const file = match[1]?.trim();
+    const line = Number.parseInt(match[2] ?? "1", 10);
+    const column = match[3] ? Number.parseInt(match[3], 10) : 1;
+    const message = match[4]?.trim() || "Validation error";
+
+    if (file && file !== currentFile) {
+      continue;
+    }
+
+    diagnostics.push(toDiagnostic(message, line, column));
+  }
+
+  return diagnostics;
+};
+
+const parseParseErrorLine = (output: string): Diagnostic[] => {
+  const diagnostics: Diagnostic[] = [];
+  const pattern = /Parse error.*line\s+(\d+)\s*:\s*(.+)$/gim;
+
+  for (const match of output.matchAll(pattern)) {
+    const line = Number.parseInt(match[1] ?? "1", 10);
+    const message = match[2]?.trim() || "Parse error";
+    diagnostics.push(toDiagnostic(message, line, 1));
+  }
+
+  return diagnostics;
+};
+
+export const parseBirdValidationOutput = (
+  output: string,
+  documentUri: Uri,
+): Diagnostic[] => {
+  const diagnostics = parseFileLineColumn(output, documentUri.fsPath);
+  if (diagnostics.length > 0) {
+    return diagnostics;
+  }
+
+  return parseParseErrorLine(output);
+};

--- a/packages/@birdcc/vscode/src/fallback/validator.ts
+++ b/packages/@birdcc/vscode/src/fallback/validator.ts
@@ -1,0 +1,163 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import {
+  DiagnosticSeverity,
+  Position,
+  Range,
+  languages,
+  window,
+  workspace,
+  type Disposable,
+  type OutputChannel,
+  type TextDocument,
+} from "vscode";
+
+import { LANGUAGE_ID } from "../constants.js";
+import type { ExtensionConfiguration } from "../types.js";
+import { parseBirdValidationOutput } from "./parser.js";
+
+const execFileAsync = promisify(execFile);
+
+export interface FallbackValidator {
+  activate: () => void;
+  validateDocument: (document: TextDocument) => Promise<void>;
+  validateActiveEditor: () => Promise<void>;
+  dispose: () => void;
+}
+
+const splitCommandLine = (commandLine: string): string[] => {
+  const tokens = commandLine.match(/"[^"]*"|'[^']*'|\S+/g) ?? [];
+  return tokens.map((token) => token.replace(/^['"]|['"]$/g, ""));
+};
+
+const renderCommandTemplate = (
+  commandTemplate: string,
+  filePath: string,
+): string[] => {
+  const rendered = commandTemplate.replaceAll("{file}", filePath);
+  return splitCommandLine(rendered);
+};
+
+const isBirdDocument = (document: TextDocument): boolean =>
+  document.languageId === LANGUAGE_ID && document.uri.scheme === "file";
+
+export const createFallbackValidator = (
+  getConfiguration: () => ExtensionConfiguration,
+  outputChannel: OutputChannel,
+): FallbackValidator => {
+  const diagnosticCollection =
+    languages.createDiagnosticCollection("bird2-fallback");
+  const disposables: Disposable[] = [];
+
+  const clearDocumentDiagnostics = (document: TextDocument): void => {
+    diagnosticCollection.delete(document.uri);
+  };
+
+  const validateDocument = async (document: TextDocument): Promise<void> => {
+    if (!isBirdDocument(document)) {
+      return;
+    }
+
+    const configuration = getConfiguration();
+    if (!configuration.validationEnabled) {
+      clearDocumentDiagnostics(document);
+      return;
+    }
+
+    const command = renderCommandTemplate(
+      configuration.validationCommand,
+      document.uri.fsPath,
+    );
+    if (command.length === 0) {
+      clearDocumentDiagnostics(document);
+      return;
+    }
+
+    const [bin, ...args] = command;
+    outputChannel.appendLine(
+      `[bird2-lsp] fallback validate: ${[bin, ...args].join(" ")}`,
+    );
+
+    try {
+      await execFileAsync(bin, args, {
+        timeout: configuration.validationTimeoutMs,
+      });
+      clearDocumentDiagnostics(document);
+    } catch (error) {
+      const typedError = error as {
+        stdout?: string;
+        stderr?: string;
+        message?: string;
+      };
+      const combinedOutput =
+        `${typedError.stdout ?? ""}\n${typedError.stderr ?? ""}`.trim();
+
+      const diagnostics = parseBirdValidationOutput(
+        combinedOutput || typedError.message || "bird -p validation failed",
+        document.uri,
+      );
+
+      if (diagnostics.length === 0) {
+        diagnosticCollection.set(document.uri, [
+          {
+            message: typedError.message || "bird -p validation failed",
+            severity: DiagnosticSeverity.Error,
+            source: "bird -p",
+            range: document.validateRange(
+              new Range(new Position(0, 0), new Position(0, 1)),
+            ),
+          },
+        ]);
+        return;
+      }
+
+      diagnosticCollection.set(document.uri, diagnostics);
+    }
+  };
+
+  const validateActiveEditor = async (): Promise<void> => {
+    const activeDocument = window.activeTextEditor?.document;
+    if (!activeDocument) {
+      return;
+    }
+
+    await validateDocument(activeDocument);
+  };
+
+  const activate = (): void => {
+    disposables.push(
+      workspace.onDidOpenTextDocument((document) => {
+        void validateDocument(document);
+      }),
+    );
+
+    disposables.push(
+      workspace.onDidSaveTextDocument((document) => {
+        if (!getConfiguration().validationOnSave) {
+          return;
+        }
+
+        void validateDocument(document);
+      }),
+    );
+
+    void validateActiveEditor();
+  };
+
+  const dispose = (): void => {
+    for (const disposable of disposables) {
+      disposable.dispose();
+    }
+    disposables.length = 0;
+    diagnosticCollection.clear();
+    diagnosticCollection.dispose();
+  };
+
+  return {
+    activate,
+    validateDocument,
+    validateActiveEditor,
+    dispose,
+  };
+};

--- a/packages/@birdcc/vscode/src/index.ts
+++ b/packages/@birdcc/vscode/src/index.ts
@@ -8,6 +8,8 @@ export {
   DEFAULT_SERVER_PATH,
   DEFAULT_TRACE_SERVER,
   DEFAULT_VALIDATION_COMMAND,
+  DEFAULT_VALIDATION_ON_SAVE,
+  DEFAULT_VALIDATION_TIMEOUT_MS,
   EXTENSION_ID,
   EXTENSION_NAME,
   LANGUAGE_ID,
@@ -38,3 +40,8 @@ export {
   type BirdClientLifecycle,
   type ClientLifecycleState,
 } from "./client/index.js";
+export {
+  createFallbackValidator,
+  parseBirdValidationOutput,
+  type FallbackValidator,
+} from "./fallback/index.js";

--- a/packages/@birdcc/vscode/src/types.ts
+++ b/packages/@birdcc/vscode/src/types.ts
@@ -8,6 +8,8 @@ import {
   DEFAULT_SERVER_PATH,
   DEFAULT_TRACE_SERVER,
   DEFAULT_VALIDATION_COMMAND,
+  DEFAULT_VALIDATION_ON_SAVE,
+  DEFAULT_VALIDATION_TIMEOUT_MS,
   EXTENSION_ID,
   EXTENSION_NAME,
 } from "./constants.js";
@@ -27,6 +29,8 @@ export const extensionConfigurationSchema = z.object({
   hiddenErrors: z.array(z.string().min(1)),
   validationEnabled: z.boolean(),
   validationCommand: z.string().min(1),
+  validationOnSave: z.boolean(),
+  validationTimeoutMs: z.number().int().min(1000).max(120000),
   formatterEngine: formatterEngineSchema,
   formatterSafeMode: z.boolean(),
 });
@@ -52,6 +56,8 @@ export const defaultExtensionConfiguration: ExtensionConfiguration =
     hiddenErrors: [...DEFAULT_HIDDEN_ERRORS],
     validationEnabled: true,
     validationCommand: DEFAULT_VALIDATION_COMMAND,
+    validationOnSave: DEFAULT_VALIDATION_ON_SAVE,
+    validationTimeoutMs: DEFAULT_VALIDATION_TIMEOUT_MS,
     formatterEngine: DEFAULT_FORMATTER_ENGINE,
     formatterSafeMode: DEFAULT_FORMATTER_SAFE_MODE,
   });


### PR DESCRIPTION
Closes #73
Part of #64
Part of #62
Part of #61

## Summary
- add fallback validator module powered by `bird -p`
- parse common BIRD error outputs into VS Code diagnostics
- add fallback lifecycle wiring in extension when `bird2-lsp.enabled` is false
- add validation settings: `bird2-lsp.validation.onSave` and `bird2-lsp.validation.timeout`

## Key Changes
- new files:
  - `src/fallback/parser.ts`
  - `src/fallback/validator.ts`
  - `src/fallback/index.ts`
- updated files:
  - `src/extension.ts`
  - `src/constants.ts`
  - `src/types.ts`
  - `src/config/configuration.ts`
  - `src/index.ts`
  - `package.json`

## Validation
- [x] `pnpm --filter @birdcc/vscode typecheck`
- [x] `pnpm --filter @birdcc/vscode build`
- [x] `pnpm --filter @birdcc/vscode lint`
- [x] `pnpm --filter @birdcc/vscode format`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm format`
