### PR TITLE
feat(vscode): implement phase-2 basic formatting provider

### DIFF
--- a/packages/@birdcc/vscode/package.json
+++ b/packages/@birdcc/vscode/package.json
@@ -165,6 +165,7 @@
     }
   },
   "dependencies": {
+    "@birdcc/formatter": "workspace:*",
     "vscode-languageclient": "^9.0.1",
     "zod": "^4.1.11"
   },

--- a/packages/@birdcc/vscode/src/extension.ts
+++ b/packages/@birdcc/vscode/src/extension.ts
@@ -1,4 +1,4 @@
-import { window, workspace } from "vscode";
+import { languages, window, workspace } from "vscode";
 import type { ExtensionContext } from "vscode";
 
 import { createBirdClientLifecycle } from "./client/index.js";
@@ -8,7 +8,9 @@ import {
   createFallbackValidator,
   type FallbackValidator,
 } from "./fallback/index.js";
+import { createBirdFormattingProvider } from "./formatter/index.js";
 import { createDefaultRuntimeState } from "./types.js";
+import { LANGUAGE_ID } from "./constants.js";
 
 export const runtimeState = createDefaultRuntimeState();
 
@@ -57,6 +59,10 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
   const outputChannel = window.createOutputChannel(EXTENSION_NAME);
   const configurationManager = createConfigurationManager();
   const lifecycle = createBirdClientLifecycle(outputChannel);
+  const formattingProvider = createBirdFormattingProvider(
+    () => runtimeState.configuration,
+    outputChannel,
+  );
   const createOrGetFallbackValidator = (): FallbackValidator => {
     if (!fallbackValidator) {
       fallbackValidator = createFallbackValidator(
@@ -95,6 +101,13 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
 
       configurationManager.refreshFromWorkspace("workspace-change");
     }),
+  );
+
+  context.subscriptions.push(
+    languages.registerDocumentFormattingEditProvider(
+      { language: LANGUAGE_ID, scheme: "file" },
+      formattingProvider,
+    ),
   );
 
   context.subscriptions.push({

--- a/packages/@birdcc/vscode/src/formatter/index.ts
+++ b/packages/@birdcc/vscode/src/formatter/index.ts
@@ -1,0 +1,1 @@
+export { createBirdFormattingProvider } from "./provider.js";

--- a/packages/@birdcc/vscode/src/formatter/provider.ts
+++ b/packages/@birdcc/vscode/src/formatter/provider.ts
@@ -1,0 +1,42 @@
+import { formatBirdConfig } from "@birdcc/formatter";
+import type { OutputChannel, TextDocument } from "vscode";
+import { Range, TextEdit, type DocumentFormattingEditProvider } from "vscode";
+
+import { LANGUAGE_ID } from "../constants.js";
+import type { ExtensionConfiguration } from "../types.js";
+
+const getDocumentFullRange = (document: TextDocument): Range =>
+  new Range(
+    document.positionAt(0),
+    document.positionAt(document.getText().length),
+  );
+
+export const createBirdFormattingProvider = (
+  getConfiguration: () => ExtensionConfiguration,
+  outputChannel: OutputChannel,
+): DocumentFormattingEditProvider => ({
+  provideDocumentFormattingEdits: async (document) => {
+    if (document.languageId !== LANGUAGE_ID) {
+      return [];
+    }
+
+    try {
+      const configuration = getConfiguration();
+      const result = await formatBirdConfig(document.getText(), {
+        engine: configuration.formatterEngine,
+        safeMode: configuration.formatterSafeMode,
+      });
+
+      if (!result.changed) {
+        return [];
+      }
+
+      return [TextEdit.replace(getDocumentFullRange(document), result.text)];
+    } catch (error) {
+      outputChannel.appendLine(
+        `[bird2-lsp] formatting failed: ${String(error)}`,
+      );
+      return [];
+    }
+  },
+});

--- a/packages/@birdcc/vscode/src/index.ts
+++ b/packages/@birdcc/vscode/src/index.ts
@@ -45,3 +45,4 @@ export {
   parseBirdValidationOutput,
   type FallbackValidator,
 } from "./fallback/index.js";
+export { createBirdFormattingProvider } from "./formatter/index.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
 
   packages/@birdcc/vscode:
     dependencies:
+      '@birdcc/formatter':
+        specifier: workspace:*
+        version: link:../formatter
       vscode-languageclient:
         specifier: ^9.0.1
         version: 9.0.1


### PR DESCRIPTION
Closes #75
Part of #64
Part of #62
Part of #61

## Summary
- add baseline `DocumentFormattingEditProvider` for BIRD documents
- integrate formatting with `@birdcc/formatter.formatBirdConfig`
- respect extension settings: `bird2-lsp.formatter.engine` and `bird2-lsp.formatter.safeMode`
- register formatting provider during extension activation

## Key Changes
- new files:
  - `src/formatter/provider.ts`
  - `src/formatter/index.ts`
- updated files:
  - `src/extension.ts`
  - `src/index.ts`
  - `package.json`
  - `pnpm-lock.yaml`

## Validation
- [x] `pnpm --filter @birdcc/vscode typecheck`
- [x] `pnpm --filter @birdcc/vscode build`
- [x] `pnpm --filter @birdcc/vscode lint`
- [x] `pnpm --filter @birdcc/vscode format`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm format`
