### PR TITLE
fix(vscode): harden command execution security for issue-77

### DIFF
--- a/packages/@birdcc/vscode/package.json
+++ b/packages/@birdcc/vscode/package.json
@@ -129,7 +129,7 @@
           "type": "string",
           "default": "bird -p -c {file}",
           "markdownDescription": "Command template for fallback validation. `{file}` will be replaced with current file path.",
-          "scope": "resource"
+          "scope": "machine-overridable"
         },
         "bird2-lsp.validation.onSave": {
           "type": "boolean",

--- a/packages/@birdcc/vscode/src/client/client.ts
+++ b/packages/@birdcc/vscode/src/client/client.ts
@@ -13,16 +13,8 @@ import {
   EXTENSION_NAME,
   LANGUAGE_ID,
 } from "../constants.js";
+import { resolveServerCommand } from "../security/index.js";
 import type { ExtensionConfiguration } from "../types.js";
-
-const toServerCommand = (serverPath: ExtensionConfiguration["serverPath"]) => {
-  if (Array.isArray(serverPath)) {
-    const [command, ...args] = serverPath;
-    return { command, args };
-  }
-
-  return { command: serverPath, args: [] as string[] };
-};
 
 const toTraceLevel = (traceServer: ExtensionConfiguration["traceServer"]) => {
   switch (traceServer) {
@@ -39,10 +31,14 @@ export const createLanguageClient = (
   configuration: ExtensionConfiguration,
   outputChannel: OutputChannel,
 ): LanguageClient => {
-  const serverCommand = toServerCommand(configuration.serverPath);
+  const serverCommand = resolveServerCommand(configuration.serverPath);
+  if (!serverCommand.ok) {
+    throw new Error(`invalid bird2-lsp.serverPath: ${serverCommand.reason}`);
+  }
+
   const serverOptions: ServerOptions = {
-    command: serverCommand.command,
-    args: serverCommand.args,
+    command: serverCommand.value.command,
+    args: [...serverCommand.value.args],
   };
 
   const clientOptions: LanguageClientOptions = {

--- a/packages/@birdcc/vscode/src/extension.ts
+++ b/packages/@birdcc/vscode/src/extension.ts
@@ -32,8 +32,17 @@ const runConfigurationLifecycle = async (
   >,
   lifecycle: ReturnType<typeof createBirdClientLifecycle>,
   createOrGetFallbackValidator: () => FallbackValidator,
+  isWorkspaceTrusted: boolean,
+  onWorkspaceTrustBlocked: () => void,
 ): Promise<void> => {
   runtimeState.configuration = change.current;
+
+  if (!isWorkspaceTrusted) {
+    disposeFallbackValidator();
+    await lifecycle.stop();
+    onWorkspaceTrustBlocked();
+    return;
+  }
 
   if (!change.current.enabled) {
     await lifecycle.stop();
@@ -63,6 +72,7 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
     () => runtimeState.configuration,
     outputChannel,
   );
+  let workspaceTrustWarningShown = false;
   const createOrGetFallbackValidator = (): FallbackValidator => {
     if (!fallbackValidator) {
       fallbackValidator = createFallbackValidator(
@@ -74,22 +84,41 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
 
     return fallbackValidator;
   };
+  const onWorkspaceTrustBlocked = (): void => {
+    if (workspaceTrustWarningShown) {
+      return;
+    }
+
+    outputChannel.appendLine(
+      "[bird2-lsp] workspace is untrusted; language client and fallback validator are disabled",
+    );
+    workspaceTrustWarningShown = true;
+  };
+  const runLifecycle = (
+    change: ReturnType<
+      ReturnType<typeof createConfigurationManager>["refreshFromWorkspace"]
+    >,
+  ): Promise<void> => {
+    if (workspace.isTrusted) {
+      workspaceTrustWarningShown = false;
+    }
+
+    return runConfigurationLifecycle(
+      change,
+      lifecycle,
+      createOrGetFallbackValidator,
+      workspace.isTrusted,
+      onWorkspaceTrustBlocked,
+    );
+  };
 
   const initialChange =
     configurationManager.refreshFromWorkspace("initial-load");
-  await runConfigurationLifecycle(
-    initialChange,
-    lifecycle,
-    createOrGetFallbackValidator,
-  );
+  await runLifecycle(initialChange);
 
   context.subscriptions.push(
     configurationManager.onDidChange((event) => {
-      void runConfigurationLifecycle(
-        event,
-        lifecycle,
-        createOrGetFallbackValidator,
-      );
+      void runLifecycle(event);
     }),
   );
 
@@ -100,6 +129,14 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
       }
 
       configurationManager.refreshFromWorkspace("workspace-change");
+    }),
+  );
+  context.subscriptions.push(
+    workspace.onDidGrantWorkspaceTrust(() => {
+      workspaceTrustWarningShown = false;
+      const change =
+        configurationManager.refreshFromWorkspace("workspace-change");
+      void runLifecycle(change);
     }),
   );
 

--- a/packages/@birdcc/vscode/src/fallback/validator.ts
+++ b/packages/@birdcc/vscode/src/fallback/validator.ts
@@ -14,6 +14,7 @@ import {
 } from "vscode";
 
 import { LANGUAGE_ID } from "../constants.js";
+import { resolveValidationCommandTemplate } from "../security/index.js";
 import type { ExtensionConfiguration } from "../types.js";
 import { parseBirdValidationOutput } from "./parser.js";
 
@@ -26,19 +27,6 @@ export interface FallbackValidator {
   dispose: () => void;
 }
 
-const splitCommandLine = (commandLine: string): string[] => {
-  const tokens = commandLine.match(/"[^"]*"|'[^']*'|\S+/g) ?? [];
-  return tokens.map((token) => token.replace(/^['"]|['"]$/g, ""));
-};
-
-const renderCommandTemplate = (
-  commandTemplate: string,
-  filePath: string,
-): string[] => {
-  const rendered = commandTemplate.replaceAll("{file}", filePath);
-  return splitCommandLine(rendered);
-};
-
 const isBirdDocument = (document: TextDocument): boolean =>
   document.languageId === LANGUAGE_ID && document.uri.scheme === "file";
 
@@ -49,6 +37,7 @@ export const createFallbackValidator = (
   const diagnosticCollection =
     languages.createDiagnosticCollection("bird2-fallback");
   const disposables: Disposable[] = [];
+  let trustWarningShown = false;
 
   const clearDocumentDiagnostics = (document: TextDocument): void => {
     diagnosticCollection.delete(document.uri);
@@ -65,16 +54,32 @@ export const createFallbackValidator = (
       return;
     }
 
-    const command = renderCommandTemplate(
+    if (!workspace.isTrusted) {
+      clearDocumentDiagnostics(document);
+      if (!trustWarningShown) {
+        outputChannel.appendLine(
+          "[bird2-lsp] workspace is untrusted; skip fallback validation command execution",
+        );
+        trustWarningShown = true;
+      }
+      return;
+    }
+
+    trustWarningShown = false;
+
+    const command = resolveValidationCommandTemplate(
       configuration.validationCommand,
       document.uri.fsPath,
     );
-    if (command.length === 0) {
+    if (!command.ok) {
+      outputChannel.appendLine(
+        `[bird2-lsp] validation command rejected: ${command.reason}`,
+      );
       clearDocumentDiagnostics(document);
       return;
     }
 
-    const [bin, ...args] = command;
+    const { command: bin, args } = command.value;
     outputChannel.appendLine(
       `[bird2-lsp] fallback validate: ${[bin, ...args].join(" ")}`,
     );
@@ -139,6 +144,13 @@ export const createFallbackValidator = (
         }
 
         void validateDocument(document);
+      }),
+    );
+
+    disposables.push(
+      workspace.onDidGrantWorkspaceTrust(() => {
+        trustWarningShown = false;
+        void validateActiveEditor();
       }),
     );
 

--- a/packages/@birdcc/vscode/src/security/command.ts
+++ b/packages/@birdcc/vscode/src/security/command.ts
@@ -1,0 +1,122 @@
+import { basename } from "node:path";
+
+import type { ExtensionConfiguration } from "../types.js";
+
+export interface ResolvedCommand {
+  readonly command: string;
+  readonly args: readonly string[];
+}
+
+export type CommandResolution =
+  | { readonly ok: true; readonly value: ResolvedCommand }
+  | { readonly ok: false; readonly reason: string };
+
+const shellExecutables = new Set([
+  "bash",
+  "sh",
+  "zsh",
+  "fish",
+  "cmd",
+  "cmd.exe",
+  "powershell",
+  "powershell.exe",
+  "pwsh",
+  "pwsh.exe",
+]);
+
+const shellExecutionFlags = new Set([
+  "-c",
+  "/c",
+  "-command",
+  "-encodedcommand",
+]);
+
+const commandTokenPattern = /"[^"]*"|'[^']*'|\S+/g;
+const validationPlaceholder = "__BIRD2_LSP_FILE_PATH__";
+
+const hasControlCharacter = (value: string): boolean =>
+  [...value].some((character) => {
+    const code = character.charCodeAt(0);
+    return code === 0 || code === 10 || code === 13;
+  });
+
+const tokenizeCommandLine = (commandLine: string): readonly string[] => {
+  const tokens = commandLine.match(commandTokenPattern) ?? [];
+  return tokens.map((token) => token.replace(/^['"]|['"]$/g, "").trim());
+};
+
+const normalizeTokens = (tokens: readonly string[]): readonly string[] =>
+  tokens.map((token) => token.trim()).filter((token) => token.length > 0);
+
+const isShellWrapper = (command: string, args: readonly string[]): boolean => {
+  const executable = basename(command).toLowerCase();
+  if (!shellExecutables.has(executable)) {
+    return false;
+  }
+
+  return args.some((arg) => shellExecutionFlags.has(arg.toLowerCase()));
+};
+
+const toCommandResolution = (tokens: readonly string[]): CommandResolution => {
+  const normalized = normalizeTokens(tokens);
+  if (normalized.length === 0) {
+    return {
+      ok: false,
+      reason: "command is empty",
+    };
+  }
+
+  if (normalized.some((token) => hasControlCharacter(token))) {
+    return {
+      ok: false,
+      reason: "command contains control characters",
+    };
+  }
+
+  const [command, ...args] = normalized;
+  if (isShellWrapper(command, args)) {
+    return {
+      ok: false,
+      reason:
+        "shell-wrapper execution is blocked (for example: bash -c, sh -c, cmd /c, powershell -command)",
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      command,
+      args,
+    },
+  };
+};
+
+const parseCommandTokens = (
+  command: ExtensionConfiguration["serverPath"],
+): readonly string[] => {
+  if (Array.isArray(command)) {
+    return normalizeTokens(command);
+  }
+
+  return tokenizeCommandLine(command);
+};
+
+export const resolveServerCommand = (
+  serverPath: ExtensionConfiguration["serverPath"],
+): CommandResolution => toCommandResolution(parseCommandTokens(serverPath));
+
+export const resolveValidationCommandTemplate = (
+  commandTemplate: string,
+  filePath: string,
+): CommandResolution => {
+  const placeholderRenderedTemplate = commandTemplate.replaceAll(
+    "{file}",
+    validationPlaceholder,
+  );
+
+  const tokens = tokenizeCommandLine(placeholderRenderedTemplate).map((token) =>
+    token.replaceAll(validationPlaceholder, filePath),
+  );
+
+  return toCommandResolution(tokens);
+};

--- a/packages/@birdcc/vscode/src/security/index.ts
+++ b/packages/@birdcc/vscode/src/security/index.ts
@@ -1,0 +1,6 @@
+export {
+  resolveServerCommand,
+  resolveValidationCommandTemplate,
+  type CommandResolution,
+  type ResolvedCommand,
+} from "./command.js";


### PR DESCRIPTION
Closes #77
Part of #67
Part of #62
Part of #61

## Summary
- add a security command module to validate and resolve external command execution paths
- block shell-wrapper style patterns (`bash -c`, `sh -c`, `cmd /c`, `powershell -command`) before launching processes
- gate LSP/fallback process execution behind workspace trust
- fix `{file}` placeholder rendering so file paths containing spaces stay a single argument
- make `bird2-lsp.validation.command` machine-overridable to reduce malicious workspace override risk

## PR #74 Review Comments Addressed
- https://github.com/bird-chinese-community/BIRD-LSP/pull/74#discussion_r2872660416
- https://github.com/bird-chinese-community/BIRD-LSP/pull/74#discussion_r2872660429

## Validation
- [x] `pnpm --filter @birdcc/vscode lint`
- [x] `pnpm --filter @birdcc/vscode typecheck`
- [x] `pnpm --filter @birdcc/vscode build`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm format`
