### PR TITLE
chore(github): add agent incident issue report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-incident-report.yml
+++ b/.github/ISSUE_TEMPLATE/agent-incident-report.yml
@@ -10,9 +10,6 @@ body:
     attributes:
       value: |
         Use this form when execution is blocked, risky, or abnormal.
-        Please include parent links using:
-        - `Part of #62`
-        - `Part of #61` (when applicable)
 
   - type: dropdown
     id: trigger
@@ -32,9 +29,11 @@ body:
   - type: input
     id: related_links
     attributes:
-      label: Related Links
-      description: Parent issue/PR links or IDs (for example #68, #62, #74).
-      placeholder: "#62, #67, #74"
+      label: Parent and Related Links
+      description: |
+        All incidents must include `Part of #62`.
+        Include `Part of #61` when applicable, plus any related issue/PR links.
+      placeholder: "Part of #62, Part of #61, #74"
     validations:
       required: true
 
@@ -90,7 +89,7 @@ body:
     attributes:
       label: Submission Checklist
       options:
-        - label: Added parent links (`Part of #62` and optional `Part of #61`).
+        - label: Added required parent links in the related links field.
           required: true
         - label: Included reproducible evidence (steps/logs).
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: BIRD-LSP Task Index
     url: https://github.com/bird-chinese-community/BIRD-LSP/issues/62


### PR DESCRIPTION
Closes #81
Part of #62
Part of #61

## Summary
- add a dedicated GitHub issue form for agent incident/blocker reporting
- include structured fields for trigger type, impact, minimal reproduction, and proposed solution
- set default labels to align with current SOP (`type/fix`, `priority/P1`, `agent/wip`)
- add issue template config with quick links to task index and epic

## Added Files
- `.github/ISSUE_TEMPLATE/agent-incident-report.yml`
- `.github/ISSUE_TEMPLATE/config.yml`

## Validation
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm format`
