### PR TITLE
fix(vscode): harden command execution and path boundaries

### DIFF
--- a/packages/@birdcc/vscode/src/fallback/validator.ts
+++ b/packages/@birdcc/vscode/src/fallback/validator.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { isAbsolute, normalize, relative, resolve } from "node:path";
 import { promisify } from "node:util";
 
 import {
@@ -29,6 +30,36 @@ export interface FallbackValidator {
 
 const isBirdDocument = (document: TextDocument): boolean =>
   document.languageId === LANGUAGE_ID && document.uri.scheme === "file";
+
+const normalizeForComparison = (filePath: string): string => {
+  const normalized = normalize(filePath);
+  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+};
+
+const isPathInsideRoot = (filePath: string, rootPath: string): boolean => {
+  const fileNormalized = normalizeForComparison(resolve(filePath));
+  const rootNormalized = normalizeForComparison(resolve(rootPath));
+  const relPath = relative(rootNormalized, fileNormalized);
+
+  if (!relPath) {
+    return true;
+  }
+
+  return !relPath.startsWith("..") && !isAbsolute(relPath);
+};
+
+const isPathInsideWorkspace = (
+  filePath: string,
+  workspaceRoots: readonly string[],
+): boolean => {
+  if (workspaceRoots.length === 0) {
+    return true;
+  }
+
+  return workspaceRoots.some((workspaceRoot) =>
+    isPathInsideRoot(filePath, workspaceRoot),
+  );
+};
 
 export const createFallbackValidator = (
   getConfiguration: () => ExtensionConfiguration,
@@ -66,6 +97,16 @@ export const createFallbackValidator = (
     }
 
     trustWarningShown = false;
+    const workspaceRoots = (
+      workspace.workspaceFolders?.map((folder) => folder.uri.fsPath) ?? []
+    ).filter((path) => path.length > 0);
+    if (!isPathInsideWorkspace(document.uri.fsPath, workspaceRoots)) {
+      outputChannel.appendLine(
+        `[bird2-lsp] validation command blocked for file outside workspace root: ${document.uri.fsPath}`,
+      );
+      clearDocumentDiagnostics(document);
+      return;
+    }
 
     const command = resolveValidationCommandTemplate(
       configuration.validationCommand,

--- a/packages/@birdcc/vscode/src/security/command.ts
+++ b/packages/@birdcc/vscode/src/security/command.ts
@@ -1,4 +1,4 @@
-import { basename } from "node:path";
+import { basename, resolve } from "node:path";
 
 import type { ExtensionConfiguration } from "../types.js";
 
@@ -30,6 +30,7 @@ const shellExecutionFlags = new Set([
   "-command",
   "-encodedcommand",
 ]);
+const disallowedShellMetacharacterPattern = /[;&|`$<>]/u;
 
 const commandTokenPattern = /"[^"]*"|'[^']*'|\S+/g;
 const validationPlaceholder = "__BIRD2_LSP_FILE_PATH__";
@@ -47,6 +48,9 @@ const tokenizeCommandLine = (commandLine: string): readonly string[] => {
 
 const normalizeTokens = (tokens: readonly string[]): readonly string[] =>
   tokens.map((token) => token.trim()).filter((token) => token.length > 0);
+
+const hasDisallowedShellMetacharacter = (value: string): boolean =>
+  disallowedShellMetacharacterPattern.test(value);
 
 const isShellWrapper = (command: string, args: readonly string[]): boolean => {
   const executable = basename(command).toLowerCase();
@@ -74,6 +78,14 @@ const toCommandResolution = (tokens: readonly string[]): CommandResolution => {
   }
 
   const [command, ...args] = normalized;
+  if (shellExecutables.has(basename(command).toLowerCase())) {
+    return {
+      ok: false,
+      reason:
+        "direct shell executable invocation is blocked (for example: bash, sh, cmd, powershell)",
+    };
+  }
+
   if (isShellWrapper(command, args)) {
     return {
       ok: false,
@@ -93,30 +105,63 @@ const toCommandResolution = (tokens: readonly string[]): CommandResolution => {
 
 const parseCommandTokens = (
   command: ExtensionConfiguration["serverPath"],
-): readonly string[] => {
+): CommandResolution => {
   if (Array.isArray(command)) {
-    return normalizeTokens(command);
+    return toCommandResolution(command);
   }
 
-  return tokenizeCommandLine(command);
+  if (hasDisallowedShellMetacharacter(command)) {
+    return {
+      ok: false,
+      reason:
+        "command string contains potentially dangerous shell metacharacters",
+    };
+  }
+
+  return toCommandResolution(tokenizeCommandLine(command));
 };
 
 export const resolveServerCommand = (
   serverPath: ExtensionConfiguration["serverPath"],
-): CommandResolution => toCommandResolution(parseCommandTokens(serverPath));
+): CommandResolution => parseCommandTokens(serverPath);
 
 export const resolveValidationCommandTemplate = (
   commandTemplate: string,
   filePath: string,
 ): CommandResolution => {
+  if (!commandTemplate.includes("{file}")) {
+    return {
+      ok: false,
+      reason: "validation command template must include the {file} placeholder",
+    };
+  }
+
+  if (hasDisallowedShellMetacharacter(commandTemplate)) {
+    return {
+      ok: false,
+      reason:
+        "validation command template contains potentially dangerous shell metacharacters",
+    };
+  }
+
   const placeholderRenderedTemplate = commandTemplate.replaceAll(
     "{file}",
     validationPlaceholder,
   );
 
-  const tokens = tokenizeCommandLine(placeholderRenderedTemplate).map((token) =>
-    token.replaceAll(validationPlaceholder, filePath),
+  const tokens = tokenizeCommandLine(placeholderRenderedTemplate);
+  if (!tokens.some((token) => token.includes(validationPlaceholder))) {
+    return {
+      ok: false,
+      reason:
+        "validation command template must place {file} in a tokenized argument",
+    };
+  }
+
+  const normalizedFilePath = resolve(filePath);
+  const resolvedTokens = tokens.map((token) =>
+    token.replaceAll(validationPlaceholder, normalizedFilePath),
   );
 
-  return toCommandResolution(tokens);
+  return toCommandResolution(resolvedTokens);
 };


### PR DESCRIPTION
## Summary
Harden VS Code extension command execution and workspace path boundaries for fallback validation.

## What Changed
- Security command resolver hardening (`src/security/command.ts`):
  - Block direct shell executable invocation (`bash`, `sh`, `cmd`, `powershell`, etc.).
  - Reject dangerous shell metacharacters in string-based command inputs.
  - Require `{file}` placeholder in validation command templates.
  - Ensure `{file}` is present in tokenized arguments before execution.
  - Normalize file path (`resolve`) before replacing `{file}`.
- Fallback validator workspace-boundary guard (`src/fallback/validator.ts`):
  - Added path-inside-workspace checks for validated documents.
  - Block validation command execution for files outside workspace roots.
  - Keep diagnostics clean when execution is blocked.

## Acceptance Checklist
- [x] Validation command resolution rejects dangerous shell metacharacter usage.
- [x] Validation command template requires `{file}` placeholder and rejects malformed tokenization.
- [x] Fallback validator refuses to execute for files outside trusted workspace roots.
- [x] `pnpm --filter @birdcc/vscode lint` passes.
- [x] `pnpm --filter @birdcc/vscode typecheck` passes.
- [x] `pnpm --filter @birdcc/vscode build` passes.

Closes #89
Part of #67
Part of #66
Part of #62
