### PR TITLE
fix(vscode): harden validation command execution and log sanitization

### DIFF
--- a/packages/@birdcc/vscode/src/client/lifecycle.ts
+++ b/packages/@birdcc/vscode/src/client/lifecycle.ts
@@ -1,6 +1,7 @@
 import type { OutputChannel } from "vscode";
 import type { LanguageClient } from "vscode-languageclient/node.js";
 
+import { toSanitizedErrorDetails } from "../security/index.js";
 import type { ExtensionConfiguration } from "../types.js";
 import { createLanguageClient } from "./client.js";
 
@@ -67,7 +68,7 @@ export const createBirdClientLifecycle = (
         setState("error");
         activeClient = undefined;
         outputChannel.appendLine(
-          `[bird2-lsp] failed to start language client: ${String(error)}`,
+          `[bird2-lsp] failed to start language client: ${toSanitizedErrorDetails(error)}`,
         );
         throw error;
       }

--- a/packages/@birdcc/vscode/src/commands/registry.ts
+++ b/packages/@birdcc/vscode/src/commands/registry.ts
@@ -11,13 +11,11 @@ import {
 
 import type { BirdClientLifecycle } from "../client/index.js";
 import { CONFIG_SECTION, EXTENSION_ID, LANGUAGE_ID } from "../constants.js";
+import { toSanitizedErrorDetails } from "../security/index.js";
 import type { ExtensionConfiguration } from "../types.js";
 
 const DOCUMENTATION_URL =
   "https://github.com/bird-chinese-community/BIRD-LSP/tree/main/packages/@birdcc/vscode";
-const toErrorDetails = (error: unknown): string =>
-  error instanceof Error ? (error.stack ?? String(error)) : String(error);
-
 export const BIRD_COMMAND_IDS = {
   restartLanguageServer: "bird2-lsp.restartLanguageServer",
   enableLanguageServer: "bird2-lsp.enableLanguageServer",
@@ -96,7 +94,7 @@ export const registerBirdCommands = (
       void window.showInformationMessage("BIRD2 language server restarted.");
     } catch (error) {
       context.outputChannel.appendLine(
-        `[bird2-lsp] restart command failed: ${toErrorDetails(error)}`,
+        `[bird2-lsp] restart command failed: ${toSanitizedErrorDetails(error)}`,
       );
       void window.showErrorMessage("Failed to restart BIRD2 language server.");
     }
@@ -114,7 +112,7 @@ export const registerBirdCommands = (
       void window.showInformationMessage("BIRD2 language server enabled.");
     } catch (error) {
       context.outputChannel.appendLine(
-        `[bird2-lsp] enable command failed: ${toErrorDetails(error)}`,
+        `[bird2-lsp] enable command failed: ${toSanitizedErrorDetails(error)}`,
       );
       void window.showErrorMessage("Failed to enable BIRD2 language server.");
     }
@@ -134,7 +132,7 @@ export const registerBirdCommands = (
       );
     } catch (error) {
       context.outputChannel.appendLine(
-        `[bird2-lsp] disable command failed: ${toErrorDetails(error)}`,
+        `[bird2-lsp] disable command failed: ${toSanitizedErrorDetails(error)}`,
       );
       void window.showErrorMessage("Failed to disable BIRD2 language server.");
     }
@@ -152,7 +150,7 @@ export const registerBirdCommands = (
       void window.showInformationMessage("BIRD2 validation command finished.");
     } catch (error) {
       context.outputChannel.appendLine(
-        `[bird2-lsp] validate command failed: ${toErrorDetails(error)}`,
+        `[bird2-lsp] validate command failed: ${toSanitizedErrorDetails(error)}`,
       );
       void window.showErrorMessage("Failed to validate active BIRD2 document.");
     }
@@ -169,7 +167,7 @@ export const registerBirdCommands = (
       await commands.executeCommand("editor.action.formatDocument");
     } catch (error) {
       context.outputChannel.appendLine(
-        `[bird2-lsp] format command failed: ${toErrorDetails(error)}`,
+        `[bird2-lsp] format command failed: ${toSanitizedErrorDetails(error)}`,
       );
       void window.showErrorMessage("Failed to format active BIRD2 document.");
     }
@@ -182,7 +180,7 @@ export const registerBirdCommands = (
       );
     } catch (error) {
       context.outputChannel.appendLine(
-        `[bird2-lsp] open settings command failed: ${toErrorDetails(error)}`,
+        `[bird2-lsp] open settings command failed: ${toSanitizedErrorDetails(error)}`,
       );
       void window.showErrorMessage("Failed to open BIRD2 extension settings.");
     }
@@ -195,7 +193,7 @@ export const registerBirdCommands = (
       await env.openExternal(Uri.parse(DOCUMENTATION_URL));
     } catch (error) {
       context.outputChannel.appendLine(
-        `[bird2-lsp] show documentation command failed: ${toErrorDetails(error)}`,
+        `[bird2-lsp] show documentation command failed: ${toSanitizedErrorDetails(error)}`,
       );
       void window.showErrorMessage("Failed to open BIRD2 documentation.");
     }
@@ -206,7 +204,7 @@ export const registerBirdCommands = (
       void window.showInformationMessage("BIRD2 configuration reloaded.");
     } catch (error) {
       context.outputChannel.appendLine(
-        `[bird2-lsp] reload configuration command failed: ${toErrorDetails(error)}`,
+        `[bird2-lsp] reload configuration command failed: ${toSanitizedErrorDetails(error)}`,
       );
       void window.showErrorMessage("Failed to reload BIRD2 configuration.");
     }

--- a/packages/@birdcc/vscode/src/fallback/validator.ts
+++ b/packages/@birdcc/vscode/src/fallback/validator.ts
@@ -14,9 +14,12 @@ import {
   type TextDocument,
 } from "vscode";
 
-import { LANGUAGE_ID } from "../constants.js";
+import { DEFAULT_VALIDATION_COMMAND, LANGUAGE_ID } from "../constants.js";
 import { enforceLargeFileGuard } from "../performance/large-file.js";
-import { resolveValidationCommandTemplate } from "../security/index.js";
+import {
+  resolveValidationCommandTemplate,
+  sanitizeLogMessage,
+} from "../security/index.js";
 import type { ExtensionConfiguration } from "../types.js";
 import { parseBirdValidationOutput } from "./parser.js";
 
@@ -70,10 +73,40 @@ export const createFallbackValidator = (
     languages.createDiagnosticCollection("bird2-fallback");
   const disposables: Disposable[] = [];
   const warningCache = new Set<string>();
+  const approvedCustomValidationCommands = new Set<string>();
   let trustWarningShown = false;
 
   const clearDocumentDiagnostics = (document: TextDocument): void => {
     diagnosticCollection.delete(document.uri);
+  };
+
+  const approveValidationCommandIfNeeded = async (
+    configuration: ExtensionConfiguration,
+  ): Promise<boolean> => {
+    const commandTemplate = configuration.validationCommand.trim();
+    if (commandTemplate === DEFAULT_VALIDATION_COMMAND) {
+      return true;
+    }
+
+    if (approvedCustomValidationCommands.has(commandTemplate)) {
+      return true;
+    }
+
+    const selection = await window.showWarningMessage(
+      [
+        "BIRD2 fallback validation will execute a custom command from workspace settings.",
+        "Only allow this if you trust the workspace and command.",
+      ].join("\n"),
+      { modal: true },
+      "Allow in this session",
+      "Cancel",
+    );
+    if (selection !== "Allow in this session") {
+      return false;
+    }
+
+    approvedCustomValidationCommands.add(commandTemplate);
+    return true;
   };
 
   const validateDocument = async (document: TextDocument): Promise<void> => {
@@ -116,7 +149,17 @@ export const createFallbackValidator = (
     ).filter((path) => path.length > 0);
     if (!isPathInsideWorkspace(document.uri.fsPath, workspaceRoots)) {
       outputChannel.appendLine(
-        `[bird2-lsp] validation command blocked for file outside workspace root: ${document.uri.fsPath}`,
+        sanitizeLogMessage(
+          `[bird2-lsp] validation command blocked for file outside workspace root: ${document.uri.fsPath}`,
+        ),
+      );
+      clearDocumentDiagnostics(document);
+      return;
+    }
+
+    if (!(await approveValidationCommandIfNeeded(configuration))) {
+      outputChannel.appendLine(
+        "[bird2-lsp] fallback validation command execution cancelled by user",
       );
       clearDocumentDiagnostics(document);
       return;
@@ -136,7 +179,9 @@ export const createFallbackValidator = (
 
     const { command: bin, args } = command.value;
     outputChannel.appendLine(
-      `[bird2-lsp] fallback validate: ${[bin, ...args].join(" ")}`,
+      sanitizeLogMessage(
+        `[bird2-lsp] fallback validate: ${[bin, ...args].join(" ")}`,
+      ),
     );
 
     try {
@@ -161,7 +206,9 @@ export const createFallbackValidator = (
       if (diagnostics.length === 0) {
         diagnosticCollection.set(document.uri, [
           {
-            message: typedError.message || "bird -p validation failed",
+            message: sanitizeLogMessage(
+              typedError.message || "bird -p validation failed",
+            ),
             severity: DiagnosticSeverity.Error,
             source: "bird -p",
             range: document.validateRange(

--- a/packages/@birdcc/vscode/src/formatter/provider.ts
+++ b/packages/@birdcc/vscode/src/formatter/provider.ts
@@ -4,6 +4,7 @@ import { Range, TextEdit, type DocumentFormattingEditProvider } from "vscode";
 
 import { LANGUAGE_ID } from "../constants.js";
 import { enforceLargeFileGuard } from "../performance/large-file.js";
+import { toSanitizedErrorDetails } from "../security/index.js";
 import type { ExtensionConfiguration } from "../types.js";
 
 const getDocumentFullRange = (document: TextDocument): Range =>
@@ -49,7 +50,7 @@ export const createBirdFormattingProvider = (
         return [TextEdit.replace(getDocumentFullRange(document), result.text)];
       } catch (error) {
         outputChannel.appendLine(
-          `[bird2-lsp] formatting failed: ${String(error)}`,
+          `[bird2-lsp] formatting failed: ${toSanitizedErrorDetails(error)}`,
         );
         return [];
       }

--- a/packages/@birdcc/vscode/src/security/command.ts
+++ b/packages/@birdcc/vscode/src/security/command.ts
@@ -31,6 +31,8 @@ const shellExecutionFlags = new Set([
   "-encodedcommand",
 ]);
 const disallowedShellMetacharacterPattern = /[;&|`$<>]/u;
+const disallowedEnvironmentExpansionPattern =
+  /\$\{env:[^}]+\}|%[a-z_][a-z0-9_]*%/iu;
 
 const commandTokenPattern = /"[^"]*"|'[^']*'|\S+/g;
 const validationPlaceholder = "__BIRD2_LSP_FILE_PATH__";
@@ -51,6 +53,8 @@ const normalizeTokens = (tokens: readonly string[]): readonly string[] =>
 
 const hasDisallowedShellMetacharacter = (value: string): boolean =>
   disallowedShellMetacharacterPattern.test(value);
+const hasDisallowedEnvironmentExpansion = (value: string): boolean =>
+  disallowedEnvironmentExpansionPattern.test(value);
 
 const isShellWrapper = (command: string, args: readonly string[]): boolean => {
   const executable = basename(command).toLowerCase();
@@ -74,6 +78,13 @@ const toCommandResolution = (tokens: readonly string[]): CommandResolution => {
     return {
       ok: false,
       reason: "command contains control characters",
+    };
+  }
+
+  if (normalized.some((token) => hasDisallowedEnvironmentExpansion(token))) {
+    return {
+      ok: false,
+      reason: "environment variable expansion syntax is blocked in commands",
     };
   }
 
@@ -141,6 +152,14 @@ export const resolveValidationCommandTemplate = (
       ok: false,
       reason:
         "validation command template contains potentially dangerous shell metacharacters",
+    };
+  }
+
+  if (hasDisallowedEnvironmentExpansion(commandTemplate)) {
+    return {
+      ok: false,
+      reason:
+        "validation command template contains blocked environment variable expansion syntax",
     };
   }
 

--- a/packages/@birdcc/vscode/src/security/index.ts
+++ b/packages/@birdcc/vscode/src/security/index.ts
@@ -4,3 +4,4 @@ export {
   type CommandResolution,
   type ResolvedCommand,
 } from "./command.js";
+export { sanitizeLogMessage, toSanitizedErrorDetails } from "./log.js";

--- a/packages/@birdcc/vscode/src/security/log.ts
+++ b/packages/@birdcc/vscode/src/security/log.ts
@@ -1,0 +1,60 @@
+import { resolve } from "node:path";
+
+import { workspace } from "vscode";
+
+const replaceAllLiteral = (
+  value: string,
+  searchValue: string,
+  replaceValue: string,
+): string => {
+  if (searchValue.length === 0) {
+    return value;
+  }
+
+  return value.split(searchValue).join(replaceValue);
+};
+
+const getPathVariants = (path: string): readonly string[] => {
+  const resolved = resolve(path);
+  const slashPath = resolved.replaceAll("\\", "/");
+  const backslashPath = resolved.replaceAll("/", "\\");
+
+  return [...new Set([resolved, slashPath, backslashPath])];
+};
+
+const sanitizeKnownPath = (
+  value: string,
+  path: string,
+  replacement: string,
+): string => {
+  let output = value;
+  for (const variant of getPathVariants(path)) {
+    output = replaceAllLiteral(output, variant, replacement);
+  }
+  return output;
+};
+
+export const sanitizeLogMessage = (message: string): string => {
+  let sanitized = message;
+
+  const workspaceRoots =
+    workspace.workspaceFolders?.map((folder) => folder.uri.fsPath) ?? [];
+  workspaceRoots
+    .filter((root) => root.length > 0)
+    .sort((left, right) => right.length - left.length)
+    .forEach((workspaceRoot) => {
+      sanitized = sanitizeKnownPath(sanitized, workspaceRoot, "<workspace>");
+    });
+
+  const home = process.env.HOME ?? process.env.USERPROFILE;
+  if (home && home.length > 0) {
+    sanitized = sanitizeKnownPath(sanitized, home, "~");
+  }
+
+  return sanitized;
+};
+
+export const toSanitizedErrorDetails = (error: unknown): string =>
+  sanitizeLogMessage(
+    error instanceof Error ? (error.stack ?? String(error)) : String(error),
+  );

--- a/packages/@birdcc/vscode/src/type-hints/provider.ts
+++ b/packages/@birdcc/vscode/src/type-hints/provider.ts
@@ -14,6 +14,7 @@ import {
 
 import { LANGUAGE_ID } from "../constants.js";
 import { enforceLargeFileGuard } from "../performance/large-file.js";
+import { toSanitizedErrorDetails } from "../security/index.js";
 import type { ExtensionConfiguration } from "../types.js";
 import {
   collectFunctionReturnHints,
@@ -29,9 +30,6 @@ interface CachedHintSnapshot {
   readonly version: number;
   readonly hints: readonly FunctionReturnHint[];
 }
-
-const toErrorDetails = (error: unknown): string =>
-  error instanceof Error ? (error.stack ?? String(error)) : String(error);
 
 const toRange = (
   line: number,
@@ -152,7 +150,7 @@ export const registerBirdTypeHintProviders = ({
           );
         } catch (error) {
           outputChannel.appendLine(
-            `[bird2-lsp] type hints hover failed: ${toErrorDetails(error)}`,
+            `[bird2-lsp] type hints hover failed: ${toSanitizedErrorDetails(error)}`,
           );
           return null;
         }
@@ -222,7 +220,7 @@ export const registerBirdTypeHintProviders = ({
             });
         } catch (error) {
           outputChannel.appendLine(
-            `[bird2-lsp] type hints inlay failed: ${toErrorDetails(error)}`,
+            `[bird2-lsp] type hints inlay failed: ${toSanitizedErrorDetails(error)}`,
           );
           return [];
         }


### PR DESCRIPTION
## Summary
- require one-time user confirmation (per session) before executing custom fallback validation commands
- block environment variable expansion syntax in command parsing (${env:...} and %VAR%)
- add centralized log sanitization for workspace/home absolute paths
- apply sanitized error details to formatter/type-hints/commands/client startup logs

## Validation
- pnpm --filter @birdcc/vscode lint
- pnpm --filter @birdcc/vscode typecheck
- pnpm --filter @birdcc/vscode build
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm format

Part of #67
Part of #62