### PR TITLE
fix(vscode): skip fallback validation for world-writable files

### DIFF
--- a/packages/@birdcc/vscode/src/fallback/validator.ts
+++ b/packages/@birdcc/vscode/src/fallback/validator.ts
@@ -68,16 +68,37 @@ const isPathInsideWorkspace = (
 
 const isWorldWritable = (mode: number): boolean => (mode & 0o002) !== 0;
 
-const isSafeFilePermission = async (filePath: string): Promise<boolean> => {
+type FilePermissionCheckResult =
+  | { readonly ok: true }
+  | {
+      readonly ok: false;
+      readonly reason: "world-writable" | "stat-failed";
+      readonly details?: string;
+    };
+
+const checkFilePermission = async (
+  filePath: string,
+): Promise<FilePermissionCheckResult> => {
   if (process.platform === "win32") {
-    return true;
+    return { ok: true };
   }
 
   try {
     const fileStat = await stat(filePath);
-    return !isWorldWritable(fileStat.mode);
-  } catch {
-    return true;
+    if (isWorldWritable(fileStat.mode)) {
+      return {
+        ok: false,
+        reason: "world-writable",
+      };
+    }
+
+    return { ok: true };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: "stat-failed",
+      details: sanitizeLogMessage(String(error)),
+    };
   }
 };
 
@@ -173,12 +194,28 @@ export const createFallbackValidator = (
       return;
     }
 
-    if (!(await isSafeFilePermission(document.uri.fsPath))) {
-      outputChannel.appendLine(
-        sanitizeLogMessage(
-          `[bird2-lsp] fallback validation skipped for world-writable file: ${document.uri.fsPath}`,
-        ),
-      );
+    const permissionCheck = await checkFilePermission(document.uri.fsPath);
+    if (!permissionCheck.ok) {
+      if (permissionCheck.reason === "world-writable") {
+        outputChannel.appendLine(
+          sanitizeLogMessage(
+            `[bird2-lsp] fallback validation skipped for world-writable file: ${document.uri.fsPath}`,
+          ),
+        );
+      } else {
+        outputChannel.appendLine(
+          sanitizeLogMessage(
+            [
+              "[bird2-lsp] fallback validation skipped because file permission check failed:",
+              document.uri.fsPath,
+              permissionCheck.details ? `(${permissionCheck.details})` : "",
+            ]
+              .join(" ")
+              .trim(),
+          ),
+        );
+      }
+
       clearDocumentDiagnostics(document);
       return;
     }

--- a/packages/@birdcc/vscode/src/security/command.ts
+++ b/packages/@birdcc/vscode/src/security/command.ts
@@ -169,11 +169,22 @@ export const resolveValidationCommandTemplate = (
   );
 
   const tokens = tokenizeCommandLine(placeholderRenderedTemplate);
-  if (!tokens.some((token) => token.includes(validationPlaceholder))) {
+  const placeholderTokens = tokens.filter((token) =>
+    token.includes(validationPlaceholder),
+  );
+  if (placeholderTokens.length === 0) {
     return {
       ok: false,
       reason:
         "validation command template must place {file} in a tokenized argument",
+    };
+  }
+
+  if (placeholderTokens.some((token) => token !== validationPlaceholder)) {
+    return {
+      ok: false,
+      reason:
+        "validation command template must place {file} as a standalone argument token",
     };
   }
 


### PR DESCRIPTION
## Summary
- add POSIX world-writable file permission guard in fallback validator
- skip external validation command execution when active document is world-writable
- log a sanitized warning and clear diagnostics for unsafe file permissions

## Validation
- pnpm --filter @birdcc/vscode lint
- pnpm --filter @birdcc/vscode typecheck
- pnpm --filter @birdcc/vscode build
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm format

Part of #67
Part of #62