### PR TITLE
perf(vscode): make extension startup non-blocking with timeout guard

### DIFF
--- a/packages/@birdcc/vscode/docs/configuration.md
+++ b/packages/@birdcc/vscode/docs/configuration.md
@@ -38,3 +38,18 @@ Example:
   "bird2-lsp.performance.maxFileSizeBytes": 4194304
 }
 ```
+
+## Startup Timeout Guard
+
+`bird2-lsp.performance.startupTimeoutMs` limits how long extension startup waits for the language server to become ready.
+
+- If startup exceeds this timeout, the extension logs a warning and keeps fallback validation available.
+- This helps avoid long activation stalls when server binaries are slow or unavailable.
+
+Example:
+
+```json
+{
+  "bird2-lsp.performance.startupTimeoutMs": 15000
+}
+```

--- a/packages/@birdcc/vscode/package.json
+++ b/packages/@birdcc/vscode/package.json
@@ -215,6 +215,14 @@
           "markdownDescription": "Skip expensive extension features when file size exceeds this byte threshold.",
           "scope": "resource"
         },
+        "bird2-lsp.performance.startupTimeoutMs": {
+          "type": "number",
+          "default": 10000,
+          "minimum": 1000,
+          "maximum": 120000,
+          "markdownDescription": "Timeout for language server startup before the extension falls back to lightweight validation.",
+          "scope": "resource"
+        },
         "bird2-lsp.formatter.engine": {
           "type": "string",
           "enum": [

--- a/packages/@birdcc/vscode/src/client/lifecycle.ts
+++ b/packages/@birdcc/vscode/src/client/lifecycle.ts
@@ -50,6 +50,30 @@ export const createBirdClientLifecycle = (
     }
   };
 
+  const startClientWithTimeout = async (
+    client: LanguageClient,
+    startupTimeoutMs: number,
+  ): Promise<void> => {
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    const startupTimeoutPromise = new Promise<never>((_, reject) => {
+      timeoutHandle = setTimeout(() => {
+        reject(
+          new Error(
+            `language client startup timed out after ${startupTimeoutMs}ms`,
+          ),
+        );
+      }, startupTimeoutMs);
+    });
+
+    try {
+      await Promise.race([client.start(), startupTimeoutPromise]);
+    } finally {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+    }
+  };
+
   const start = async (configuration: ExtensionConfiguration): Promise<void> =>
     runExclusive(async () => {
       if (state === "running") {
@@ -61,10 +85,20 @@ export const createBirdClientLifecycle = (
 
       try {
         activeClient = createLanguageClient(configuration, outputChannel);
-        await activeClient.start();
+        await startClientWithTimeout(
+          activeClient,
+          configuration.lspStartupTimeoutMs,
+        );
         setState("running");
         outputChannel.appendLine("[bird2-lsp] language client started");
       } catch (error) {
+        if (activeClient) {
+          try {
+            await activeClient.stop();
+          } catch {
+            // best effort cleanup; startup may already be partially failed
+          }
+        }
         setState("error");
         activeClient = undefined;
         outputChannel.appendLine(
@@ -105,7 +139,10 @@ export const createBirdClientLifecycle = (
 
       setState("starting");
       activeClient = createLanguageClient(configuration, outputChannel);
-      await activeClient.start();
+      await startClientWithTimeout(
+        activeClient,
+        configuration.lspStartupTimeoutMs,
+      );
       setState("running");
       outputChannel.appendLine("[bird2-lsp] language client restarted");
     });

--- a/packages/@birdcc/vscode/src/config/configuration.ts
+++ b/packages/@birdcc/vscode/src/config/configuration.ts
@@ -20,6 +20,7 @@ import {
   DEFAULT_VALIDATION_ON_SAVE,
   DEFAULT_VALIDATION_TIMEOUT_MS,
   DEFAULT_PERFORMANCE_MAX_FILE_SIZE_BYTES,
+  DEFAULT_PERFORMANCE_STARTUP_TIMEOUT_MS,
   RESTART_REQUIRED_CONFIGURATION_PATHS,
 } from "../constants.js";
 import {
@@ -77,6 +78,10 @@ const readWorkspaceConfiguration = (): ExtensionConfiguration => {
     performanceMaxFileSizeBytes: config.get(
       "performance.maxFileSizeBytes",
       DEFAULT_PERFORMANCE_MAX_FILE_SIZE_BYTES,
+    ),
+    lspStartupTimeoutMs: config.get(
+      "performance.startupTimeoutMs",
+      DEFAULT_PERFORMANCE_STARTUP_TIMEOUT_MS,
     ),
     formatterEngine: config.get("formatter.engine", DEFAULT_FORMATTER_ENGINE),
     formatterSafeMode: config.get(

--- a/packages/@birdcc/vscode/src/constants.ts
+++ b/packages/@birdcc/vscode/src/constants.ts
@@ -16,6 +16,7 @@ export const DEFAULT_VALIDATION_COMMAND = "bird -p -c {file}";
 export const DEFAULT_VALIDATION_ON_SAVE = true;
 export const DEFAULT_VALIDATION_TIMEOUT_MS = 30000;
 export const DEFAULT_PERFORMANCE_MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024;
+export const DEFAULT_PERFORMANCE_STARTUP_TIMEOUT_MS = 10000;
 export const DEFAULT_FORMATTER_ENGINE = "dprint" as const;
 export const DEFAULT_FORMATTER_SAFE_MODE = true;
 export const DEFAULT_TYPE_HINTS_ENABLED = true;

--- a/packages/@birdcc/vscode/src/extension.ts
+++ b/packages/@birdcc/vscode/src/extension.ts
@@ -14,6 +14,7 @@ import { createBirdStatusBarManager } from "./status/index.js";
 import { registerBirdTypeHintProviders } from "./type-hints/index.js";
 import { createDefaultRuntimeState } from "./types.js";
 import { LANGUAGE_ID } from "./constants.js";
+import { toSanitizedErrorDetails } from "./security/index.js";
 
 export const runtimeState = createDefaultRuntimeState();
 
@@ -132,11 +133,26 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
       refreshStatus,
     );
   };
+  const runLifecycleSafely = (
+    change: ReturnType<
+      ReturnType<typeof createConfigurationManager>["refreshFromWorkspace"]
+    >,
+    source: "initial-load" | "configuration-change" | "workspace-trust",
+  ): void => {
+    void runLifecycle(change).catch((error) => {
+      outputChannel.appendLine(
+        `[bird2-lsp] lifecycle update failed (${source}): ${toSanitizedErrorDetails(error)}`,
+      );
+      const validator = createOrGetFallbackValidator();
+      void validator.validateActiveEditor();
+      refreshStatus();
+    });
+  };
   const reloadConfiguration = async (): Promise<void> => {
     const change =
       configurationManager.refreshFromWorkspace("workspace-change");
     if (change.changedPaths.length === 0) {
-      await runLifecycle(change);
+      runLifecycleSafely(change, "configuration-change");
     }
   };
   const validateActiveDocument = async (): Promise<void> => {
@@ -160,11 +176,11 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
 
   const initialChange =
     configurationManager.refreshFromWorkspace("initial-load");
-  await runLifecycle(initialChange);
+  runLifecycleSafely(initialChange, "initial-load");
 
   context.subscriptions.push(
     configurationManager.onDidChange((event) => {
-      void runLifecycle(event);
+      runLifecycleSafely(event, "configuration-change");
     }),
   );
 
@@ -182,7 +198,7 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
       workspaceTrustWarningShown = false;
       const change =
         configurationManager.refreshFromWorkspace("workspace-change");
-      void runLifecycle(change);
+      runLifecycleSafely(change, "workspace-trust");
     }),
   );
 

--- a/packages/@birdcc/vscode/src/types.ts
+++ b/packages/@birdcc/vscode/src/types.ts
@@ -14,6 +14,7 @@ import {
   DEFAULT_VALIDATION_ON_SAVE,
   DEFAULT_VALIDATION_TIMEOUT_MS,
   DEFAULT_PERFORMANCE_MAX_FILE_SIZE_BYTES,
+  DEFAULT_PERFORMANCE_STARTUP_TIMEOUT_MS,
   EXTENSION_ID,
   EXTENSION_NAME,
 } from "./constants.js";
@@ -40,6 +41,7 @@ export const extensionConfigurationSchema = z.object({
     .int()
     .min(64 * 1024)
     .max(100 * 1024 * 1024),
+  lspStartupTimeoutMs: z.number().int().min(1000).max(120000),
   formatterEngine: formatterEngineSchema,
   formatterSafeMode: z.boolean(),
   typeHintsEnabled: z.boolean(),
@@ -71,6 +73,7 @@ export const defaultExtensionConfiguration: ExtensionConfiguration =
     validationOnSave: DEFAULT_VALIDATION_ON_SAVE,
     validationTimeoutMs: DEFAULT_VALIDATION_TIMEOUT_MS,
     performanceMaxFileSizeBytes: DEFAULT_PERFORMANCE_MAX_FILE_SIZE_BYTES,
+    lspStartupTimeoutMs: DEFAULT_PERFORMANCE_STARTUP_TIMEOUT_MS,
     formatterEngine: DEFAULT_FORMATTER_ENGINE,
     formatterSafeMode: DEFAULT_FORMATTER_SAFE_MODE,
     typeHintsEnabled: DEFAULT_TYPE_HINTS_ENABLED,

--- a/packages/@birdcc/vscode/test/types.test.ts
+++ b/packages/@birdcc/vscode/test/types.test.ts
@@ -12,12 +12,14 @@ describe("extension configuration parsing", () => {
       enabled: false,
       validationTimeoutMs: 45_000,
       performanceMaxFileSizeBytes: 4 * 1024 * 1024,
+      lspStartupTimeoutMs: 15_000,
       formatterEngine: "builtin",
     });
 
     expect(parsed.enabled).toBe(false);
     expect(parsed.validationTimeoutMs).toBe(45_000);
     expect(parsed.performanceMaxFileSizeBytes).toBe(4 * 1024 * 1024);
+    expect(parsed.lspStartupTimeoutMs).toBe(15_000);
     expect(parsed.formatterEngine).toBe("builtin");
   });
 
@@ -25,6 +27,7 @@ describe("extension configuration parsing", () => {
     const parsed = parseExtensionConfiguration({
       ...defaultExtensionConfiguration,
       performanceMaxFileSizeBytes: 32,
+      lspStartupTimeoutMs: 100,
     });
 
     expect(parsed).toEqual(defaultExtensionConfiguration);


### PR DESCRIPTION
Part of #66
Part of #62

## Summary
- make initial extension lifecycle startup non-blocking (do not await first lifecycle run in activate)
- add language client startup timeout guard (`bird2-lsp.performance.startupTimeoutMs`, default 10000ms)
- keep lifecycle failures non-fatal and trigger fallback validator validation when startup/update fails
- wire new config through constants/types/configuration schema and VS Code contributes settings
- extend type configuration tests for the new timeout field

## Acceptance
- [x] `pnpm --filter @birdcc/vscode lint`
- [x] `pnpm --filter @birdcc/vscode typecheck`
- [x] `pnpm --filter @birdcc/vscode test`
- [x] `pnpm --filter @birdcc/vscode build`
- [x] `pnpm --filter @birdcc/vscode format`

## Notes
- This PR targets #66 performance blockers and does not close #66 yet.
- Startup timeout fallback keeps extension responsive when server startup hangs or binary resolution fails slowly.
