### PR TITLE
fix(vscode): prevent orphaned client on startup-timeout race

### DIFF
--- a/packages/@birdcc/vscode/src/client/lifecycle.ts
+++ b/packages/@birdcc/vscode/src/client/lifecycle.ts
@@ -35,20 +35,10 @@ export const createBirdClientLifecycle = (
   let state: ClientLifecycleState = "idle";
   let activeClient: LanguageClient | undefined;
   let activeOperation: Promise<void> | undefined;
-  let pendingStartupCleanup: Promise<void> | undefined;
+  let startupCleanupPending = false;
   const setState = (nextState: ClientLifecycleState): void => {
     state = nextState;
     options.onStateChange?.(nextState);
-  };
-
-  const awaitPendingStartupCleanup = async (): Promise<void> => {
-    while (pendingStartupCleanup) {
-      const currentCleanup = pendingStartupCleanup;
-      await currentCleanup;
-      if (pendingStartupCleanup === currentCleanup) {
-        pendingStartupCleanup = undefined;
-      }
-    }
   };
 
   const runExclusive = async (operation: () => Promise<void>) => {
@@ -59,8 +49,6 @@ export const createBirdClientLifecycle = (
         // previous operation failure must not block queued lifecycle operations
       }
     }
-
-    await awaitPendingStartupCleanup();
 
     const operationPromise = operation();
     activeOperation = operationPromise;
@@ -96,22 +84,29 @@ export const createBirdClientLifecycle = (
       const timeoutError = new StartupTimeoutError(
         `language client startup timed out after ${startupTimeoutMs}ms`,
       );
-      pendingStartupCleanup = (async () => {
+      startupCleanupPending = true;
+      void (async () => {
         try {
-          await startPromise;
-        } catch {
-          return;
-        }
+          try {
+            await startPromise;
+          } catch (error) {
+            outputChannel.appendLine(
+              `[bird2-lsp] startup-timeout cleanup startup result: ${toSanitizedErrorDetails(error)}`,
+            );
+            return;
+          }
 
-        try {
-          await client.stop();
-        } catch (error) {
-          outputChannel.appendLine(
-            `[bird2-lsp] startup-timeout cleanup stop failed: ${toSanitizedErrorDetails(error)}`,
-          );
+          try {
+            await client.stop();
+          } catch (error) {
+            outputChannel.appendLine(
+              `[bird2-lsp] startup-timeout cleanup stop failed: ${toSanitizedErrorDetails(error)}`,
+            );
+          }
+        } finally {
+          startupCleanupPending = false;
         }
       })();
-      await pendingStartupCleanup;
       throw timeoutError;
     } finally {
       if (timeoutHandle) {
@@ -124,6 +119,11 @@ export const createBirdClientLifecycle = (
     runExclusive(async () => {
       if (state === "running") {
         return;
+      }
+      if (startupCleanupPending) {
+        throw new Error(
+          "previous timed-out startup is still cleaning up in background",
+        );
       }
 
       setState("starting");
@@ -177,20 +177,42 @@ export const createBirdClientLifecycle = (
     configuration: ExtensionConfiguration,
   ): Promise<void> =>
     runExclusive(async () => {
+      if (startupCleanupPending) {
+        throw new Error(
+          "previous timed-out startup is still cleaning up in background",
+        );
+      }
+
       if (activeClient) {
         setState("stopping");
         outputChannel.appendLine("[bird2-lsp] restarting language client");
         await activeClient.stop();
       }
 
-      setState("starting");
-      activeClient = createLanguageClient(configuration, outputChannel);
-      await startClientWithTimeout(
-        activeClient,
-        configuration.lspStartupTimeoutMs,
-      );
-      setState("running");
-      outputChannel.appendLine("[bird2-lsp] language client restarted");
+      try {
+        setState("starting");
+        activeClient = createLanguageClient(configuration, outputChannel);
+        await startClientWithTimeout(
+          activeClient,
+          configuration.lspStartupTimeoutMs,
+        );
+        setState("running");
+        outputChannel.appendLine("[bird2-lsp] language client restarted");
+      } catch (error) {
+        if (activeClient && !(error instanceof StartupTimeoutError)) {
+          try {
+            await activeClient.stop();
+          } catch {
+            // best effort cleanup; startup may already be partially failed
+          }
+        }
+        setState("error");
+        activeClient = undefined;
+        outputChannel.appendLine(
+          `[bird2-lsp] failed to restart language client: ${toSanitizedErrorDetails(error)}`,
+        );
+        throw error;
+      }
     });
 
   const dispose = async (): Promise<void> => {

--- a/packages/@birdcc/vscode/test/client-lifecycle.test.ts
+++ b/packages/@birdcc/vscode/test/client-lifecycle.test.ts
@@ -46,7 +46,7 @@ describe("client lifecycle startup timeout cleanup", () => {
     vi.clearAllMocks();
   });
 
-  it("waits startup completion before stopping timed-out client", async () => {
+  it("rejects timeout promptly and keeps cleanup in background", async () => {
     const startDeferred = createDeferred<void>();
     let running = false;
     const client = {
@@ -67,18 +67,18 @@ describe("client lifecycle startup timeout cleanup", () => {
     const lifecycle = createBirdClientLifecycle(createOutputChannelMock());
     const startPromise = lifecycle.start(createConfiguration(20));
 
-    await sleep(40);
-    expect(client.stop).not.toHaveBeenCalled();
-
-    startDeferred.resolve();
     await expect(startPromise).rejects.toThrow(
       "language client startup timed out",
     );
+    expect(client.stop).not.toHaveBeenCalled();
+
+    startDeferred.resolve();
+    await sleep(10);
     expect(client.stop).toHaveBeenCalledTimes(1);
     expect(lifecycle.state).toBe("error");
   });
 
-  it("does not create a second client before timed-out startup cleanup finishes", async () => {
+  it("rejects new start attempts while timeout cleanup is still pending", async () => {
     const firstStartDeferred = createDeferred<void>();
     let firstRunning = false;
     const firstClient = {
@@ -106,14 +106,16 @@ describe("client lifecycle startup timeout cleanup", () => {
     const lifecycle = createBirdClientLifecycle(createOutputChannelMock());
     const firstStart = lifecycle.start(createConfiguration(20));
 
-    await sleep(40);
+    await expect(firstStart).rejects.toThrow("startup timed out");
     const secondStart = lifecycle.start(createConfiguration(20));
-    await sleep(10);
+    await expect(secondStart).rejects.toThrow(
+      "previous timed-out startup is still cleaning up in background",
+    );
     expect(vi.mocked(createLanguageClient)).toHaveBeenCalledTimes(1);
 
     firstStartDeferred.resolve();
-    await expect(firstStart).rejects.toThrow("startup timed out");
-    await secondStart;
+    await sleep(10);
+    await lifecycle.start(createConfiguration(20));
 
     expect(vi.mocked(createLanguageClient)).toHaveBeenCalledTimes(2);
     expect(secondClient.start).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Part of #66
Part of #62

## Context
This fixes a P1 race introduced by the startup-timeout guard: when timeout won `Promise.race`, `client.start()` could still complete in background and leave an orphaned running client.

## Changes
- rework startup-timeout logic in `createBirdClientLifecycle`:
  - keep a handle to the original `start()` promise
  - on timeout, wait for startup promise settlement, then perform cleanup stop
  - store cleanup promise and gate subsequent lifecycle operations until cleanup completes
- make lifecycle queue robust after failures: waiting callers no longer inherit previous operation rejection
- add regression tests (`test/client-lifecycle.test.ts`) covering:
  - timeout cleanup waits for startup completion before stop
  - no second client is created before timeout-cleanup finishes

## Validation
- [x] `pnpm --filter @birdcc/vscode format`
- [x] `pnpm --filter @birdcc/vscode lint`
- [x] `pnpm --filter @birdcc/vscode typecheck`
- [x] `pnpm --filter @birdcc/vscode test`
- [x] `pnpm --filter @birdcc/vscode build`
