### PR TITLE
chore(core): operationalize IP benchmark and perf workflow

### DIFF
--- a/.github/workflows/perf-realworld.yml
+++ b/.github/workflows/perf-realworld.yml
@@ -23,6 +23,10 @@ on:
         description: "Worker timeout (ms) when isolate=true"
         required: false
         default: "60000"
+      ip_bench_sample_size:
+        description: "Sample size for core IP benchmark"
+        required: false
+        default: "100000"
 
 jobs:
   bench:
@@ -43,6 +47,10 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
+      - name: Run core node-vs-regex IP benchmark
+        run: |
+          BENCH_SAMPLE_SIZE="${{ inputs.ip_bench_sample_size }}" \
+            pnpm --filter @birdcc/core bench:ip-check | tee bench-ip-check.txt
       - run: |
           EXTRA_ARGS=""
           if [ "${{ inputs.isolate }}" = "true" ]; then
@@ -58,4 +66,6 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: bench-realworld-configs
-          path: bench-realworld.json
+          path: |
+            bench-realworld.json
+            bench-ip-check.txt

--- a/packages/@birdcc/core/package.json
+++ b/packages/@birdcc/core/package.json
@@ -23,6 +23,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "bench:ip-check": "node scripts/benchmark-node-vs-regex.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "oxlint --deny-warnings src test",
     "test": "vitest run",

--- a/packages/@birdcc/core/scripts/benchmark-node-vs-regex.js
+++ b/packages/@birdcc/core/scripts/benchmark-node-vs-regex.js
@@ -1,4 +1,4 @@
-// Run: node bench-ip.mjs
+// Run: pnpm --filter @birdcc/core bench:ip-check
 
 import { bench, run, summary, barplot } from "mitata";
 import { isIP } from "node:net";
@@ -34,16 +34,26 @@ const samples = [
   "999.999.999.999", // invalid (out of range)
 ];
 
-const sample100k = Array.from(
-  { length: 100000 },
-  () => samples[Math.floor(Math.random() * samples.length)],
-);
+const parseSampleSize = (value) => {
+  const parsed = Number.parseInt(value ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return 100000;
+  }
+  return parsed;
+};
+
+const sampleSize = parseSampleSize(process.env.BENCH_SAMPLE_SIZE);
+const samplePool = Array.from({ length: sampleSize }, (_, index) => {
+  return samples[index % samples.length];
+});
 
 // Sanity-check: both implementations must agree on every sample
 for (const s of samples) {
   const r = isIP_regex(s);
   const n = isIP(s);
-  if (r !== n) console.warn(`[mismatch] "${s}"  regex=${r}  node=${n}`);
+  if (r !== n) {
+    throw new Error(`[mismatch] "${s}" regex=${r} node=${n}`);
+  }
 }
 
 // --- benchmarks ---
@@ -64,11 +74,11 @@ summary(() => {
     bench("node   · 10-sample mixed loop", () => {
       for (const s of samples) isIP(s);
     });
-    bench("regex  · 100k-sample random loop", () => {
-      for (const s of sample100k) isIP_regex(s);
+    bench(`regex  · ${sampleSize}-sample deterministic loop`, () => {
+      for (const s of samplePool) isIP_regex(s);
     });
-    bench("node   · 100k-sample random loop", () => {
-      for (const s of sample100k) isIP(s);
+    bench(`node   · ${sampleSize}-sample deterministic loop`, () => {
+      for (const s of samplePool) isIP(s);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Added first-class benchmark command for core IP validation benchmark.
- Improved benchmark determinism and mismatch handling.
- Integrated benchmark output capture into perf workflow artifacts.

## Changes
- `@birdcc/core` adds `bench:ip-check` script.
- `benchmark-node-vs-regex.js` now:
  - uses deterministic sample pool (configurable via `BENCH_SAMPLE_SIZE`)
  - throws on mismatch instead of warning
  - keeps node-vs-regex comparison output stable for CI artifacts
- `.github/workflows/perf-realworld.yml` now:
  - supports `ip_bench_sample_size` input
  - runs core benchmark step
  - uploads `bench-ip-check.txt` alongside `bench-realworld.json`

## Validation
- [x] `pnpm --filter @birdcc/core bench:ip-check`
- [x] `pnpm --filter @birdcc/core lint`
- [x] `pnpm --filter @birdcc/core typecheck`
- [x] `pnpm --filter @birdcc/core test`
- [x] `pnpm --filter @birdcc/core build`
- [x] `pnpm lint`
- [x] `pnpm typecheck`

Closes #104
Part of #62
