### PR TITLE
fix(cli): Set bird -p working directory to config file location

### DIFF
--- a/packages/@birdcc/cli/src/index.ts
+++ b/packages/@birdcc/cli/src/index.ts
@@ -215,7 +215,11 @@ interface CommandExecResult {
   errorReason?: string;
 }
 
-const runCommand = (executable: string, args: string[]): CommandExecResult => {
+const runCommand = (
+  executable: string,
+  args: string[],
+  cwd?: string,
+): CommandExecResult => {
   if (!executable) {
     return {
       command: "",
@@ -230,6 +234,7 @@ const runCommand = (executable: string, args: string[]): CommandExecResult => {
     encoding: "utf8",
     timeout: COMMAND_TIMEOUT_MS,
     killSignal: "SIGTERM",
+    ...(cwd ? { cwd } : {}),
   });
 
   if (result.error) {
@@ -353,6 +358,7 @@ export const runBirdValidation = (
   const execResult = runCommand(
     expandedCommand.executable,
     expandedCommand.args,
+    dirname(filePath),
   );
 
   if (execResult.errorReason) {

--- a/packages/@birdcc/cli/src/index.ts
+++ b/packages/@birdcc/cli/src/index.ts
@@ -234,7 +234,7 @@ const runCommand = (
     encoding: "utf8",
     timeout: COMMAND_TIMEOUT_MS,
     killSignal: "SIGTERM",
-    ...(cwd ? { cwd } : {}),
+    cwd,
   });
 
   if (result.error) {
@@ -310,6 +310,9 @@ export const runBirdValidation = (
   filePath: string,
   validateCommand?: string,
 ): BirdValidateResult => {
+  // Resolve to absolute so cwd and {file} replacement stay consistent
+  // even when filePath is a relative path with directory components.
+  const resolvedFilePath = resolve(filePath);
   const validateTemplate = resolveValidateTemplate(validateCommand);
   const commandTokens = parseCommandTokens(validateTemplate);
   if (!commandTokens || commandTokens.length === 0) {
@@ -333,7 +336,10 @@ export const runBirdValidation = (
     };
   }
 
-  const expandedCommand = expandValidateCommandArgs(commandTokens, filePath);
+  const expandedCommand = expandValidateCommandArgs(
+    commandTokens,
+    resolvedFilePath,
+  );
   if (!expandedCommand) {
     const message = createBirdRunnerErrorMessage(
       "invalid bird command template or unsafe file path for command execution",
@@ -358,7 +364,7 @@ export const runBirdValidation = (
   const execResult = runCommand(
     expandedCommand.executable,
     expandedCommand.args,
-    dirname(filePath),
+    dirname(resolvedFilePath),
   );
 
   if (execResult.errorReason) {


### PR DESCRIPTION
## Summary

When running `bird -p -c {file}` validation, the working directory is now set to the config file's directory. This ensures BIRD resolves relative `include` paths correctly.

## Problem

BIRD resolves relative include paths against the current working directory, NOT the config file's directory. When `bird -p` is invoked from a different directory, includes like `include "vars.conf";` fail because `vars.conf` is not found relative to the process cwd.

## Fix

`runCommand()` now accepts an optional `cwd` parameter. `runBirdValidation()` passes `dirname(filePath)` as the working directory, so BIRD runs in the same directory as the config file.

## Before

```
cd /home/user && bird -p -c /etc/bird/bird.conf
# BIRD resolves includes relative to /home/user, not /etc/bird/
```

## After

```
bird -p -c /etc/bird/bird.conf
# cwd = /etc/bird/ → includes resolve correctly
```

## Checklist

- [x] All 38 CLI tests pass
- [x] Full monorepo test suite green
- [x] Lint & format pass