### PR TITLE
feat(parser): Misc protocols, OSPF core, RIP, and upstream linter/LSP adaptations

### DIFF
--- a/packages/@birdcc/linter/src/rules/bgp.ts
+++ b/packages/@birdcc/linter/src/rules/bgp.ts
@@ -261,7 +261,13 @@ const bgpTimerInvalidRule: BirdRule = ({ parsed }) => {
       }
     }
 
-    if (hold !== null && keepalive !== null && keepalive >= hold) {
+    if (
+      hold !== null &&
+      keepalive !== null &&
+      hold !== 0 &&
+      keepalive !== 0 &&
+      keepalive >= hold
+    ) {
       diagnostics.push(
         createProtocolDiagnostic(
           "bgp/timer-invalid",

--- a/packages/@birdcc/linter/src/rules/bgp.ts
+++ b/packages/@birdcc/linter/src/rules/bgp.ts
@@ -199,11 +199,11 @@ const bgpTimerInvalidRule: BirdRule = ({ parsed }) => {
         const value = numericValue(statement.value);
         if (statement.option === "hold-time") {
           hold = value;
-          if (value !== null && (value < 3 || value > 65_535)) {
+          if (value !== null && value !== 0 && (value < 3 || value > 65_535)) {
             diagnostics.push(
               createRuleDiagnostic(
                 "bgp/timer-invalid",
-                `BGP protocol '${declaration.name}' hold time must be in range 3..65535`,
+                `BGP protocol '${declaration.name}' hold time must be in range 3..65535 or 0 to disable`,
                 statement.valueRange,
               ),
             );
@@ -212,11 +212,11 @@ const bgpTimerInvalidRule: BirdRule = ({ parsed }) => {
 
         if (statement.option === "keepalive-time") {
           keepalive = value;
-          if (value !== null && (value < 1 || value > 65_535)) {
+          if (value !== null && value !== 0 && (value < 1 || value > 65_535)) {
             diagnostics.push(
               createRuleDiagnostic(
                 "bgp/timer-invalid",
-                `BGP protocol '${declaration.name}' keepalive must be in range 1..65535`,
+                `BGP protocol '${declaration.name}' keepalive must be in range 1..65535 or 0 to disable`,
                 statement.valueRange,
               ),
             );
@@ -236,11 +236,11 @@ const bgpTimerInvalidRule: BirdRule = ({ parsed }) => {
 
       if (holdValue !== null) {
         hold = holdValue;
-        if (hold < 3 || hold > 65_535) {
+        if (hold !== 0 && (hold < 3 || hold > 65_535)) {
           diagnostics.push(
             createRuleDiagnostic(
               "bgp/timer-invalid",
-              `BGP protocol '${declaration.name}' hold time must be in range 3..65535`,
+              `BGP protocol '${declaration.name}' hold time must be in range 3..65535 or 0 to disable`,
               statement,
             ),
           );
@@ -249,11 +249,11 @@ const bgpTimerInvalidRule: BirdRule = ({ parsed }) => {
 
       if (keepaliveValue !== null) {
         keepalive = keepaliveValue;
-        if (keepalive < 1 || keepalive > 65_535) {
+        if (keepalive !== 0 && (keepalive < 1 || keepalive > 65_535)) {
           diagnostics.push(
             createRuleDiagnostic(
               "bgp/timer-invalid",
-              `BGP protocol '${declaration.name}' keepalive must be in range 1..65535`,
+              `BGP protocol '${declaration.name}' keepalive must be in range 1..65535 or 0 to disable`,
               statement,
             ),
           );

--- a/packages/@birdcc/linter/src/rules/bgp.ts
+++ b/packages/@birdcc/linter/src/rules/bgp.ts
@@ -276,6 +276,16 @@ const bgpTimerInvalidRule: BirdRule = ({ parsed }) => {
         ),
       );
     }
+
+    if (hold === 0 && keepalive !== null && keepalive !== 0) {
+      diagnostics.push(
+        createProtocolDiagnostic(
+          "bgp/timer-invalid",
+          `BGP protocol '${declaration.name}' keepalive (${keepalive}) must be 0 when hold time is disabled`,
+          declaration,
+        ),
+      );
+    }
   }
 
   return diagnostics;

--- a/packages/@birdcc/linter/src/rules/ospf.ts
+++ b/packages/@birdcc/linter/src/rules/ospf.ts
@@ -40,6 +40,8 @@ const stripComments = (value: string): string =>
 
 const stripNestedBlocks = (value: string): string => {
   const cleaned = stripComments(value);
+  const hasOuterBraces = cleaned.trimStart().startsWith("{");
+  const targetDepth = hasOuterBraces ? 1 : 0;
   let result = "";
   let depth = 0;
   for (let index = 0; index < cleaned.length; index += 1) {
@@ -52,7 +54,7 @@ const stripNestedBlocks = (value: string): string => {
       depth = Math.max(0, depth - 1);
       continue;
     }
-    if (depth <= 1) {
+    if (depth === targetDepth) {
       result += char;
     }
   }

--- a/packages/@birdcc/linter/src/rules/ospf.ts
+++ b/packages/@birdcc/linter/src/rules/ospf.ts
@@ -32,7 +32,7 @@ const isAsbrEnabled = (text: string): boolean => {
 
   // Disabled forms: "no asbr", "asbr no", "asbr off", "asbr false".
   return (
-    !/^\s*no\s+asbr\b/i.test(normalized) &&
+    !/\bno\s+asbr\b/i.test(normalized) &&
     !/\basbr\s+(?:no|off|false)\b/i.test(normalized)
   );
 };

--- a/packages/@birdcc/linter/src/rules/ospf.ts
+++ b/packages/@birdcc/linter/src/rules/ospf.ts
@@ -34,22 +34,25 @@ const stripComments = (value: string): string =>
   value
     .replace(
       /"[^"\\]*(?:\\.[^"\\]*)*"|'[^'\\]*(?:\\.[^'\\]*)*'|(#.*|\/\*[\s\S]*?\*\/)/gu,
-      (match, group) => (group ? "" : match),
+      "",
     )
     .trim();
 
-const isAsbrEnabled = (text: string): boolean => {
+const getAsbrState = (text: string): "enabled" | "disabled" | "none" => {
   const normalized = stripComments(text).toLowerCase();
   if (!/\basbr\b/i.test(normalized)) {
-    return false;
+    return "none";
   }
 
-  // Disabled forms: "no asbr", "asbr no", "asbr off", "asbr false".
-  return (
-    !/\bno\s+asbr\b/i.test(normalized) &&
-    !/\basbr\s+(?:no|off|false)\b/i.test(normalized)
-  );
+  const isDisabled =
+    /\bno\s+asbr\b/i.test(normalized) ||
+    /\basbr\s+(?:no|off|false)\b/i.test(normalized);
+
+  return isDisabled ? "disabled" : "enabled";
 };
+
+const isAsbrEnabled = (text: string): boolean =>
+  getAsbrState(text) === "enabled";
 
 const hasProtocolAsbr = (
   declaration: ProtocolDeclaration,
@@ -68,16 +71,25 @@ const hasProtocolAsbr = (
         (
           statement,
         ): statement is Extract<ProtocolStatement, { kind: "other" }> =>
-          statement.kind === "other" && /\basbr\b/i.test(statement.text),
+          statement.kind === "other",
       );
-      if (asbrStatements.length > 0) {
-        const lastStatement = asbrStatements[asbrStatements.length - 1];
-        return isAsbrEnabled(lastStatement.text);
+      for (let index = asbrStatements.length - 1; index >= 0; index -= 1) {
+        const state = getAsbrState(asbrStatements[index]?.text ?? "");
+        if (state === "enabled") {
+          return true;
+        }
+        if (state === "disabled") {
+          return false;
+        }
       }
     } else if (current.kind === "template") {
       const bodyText = current.bodyText ?? "";
-      if (/\basbr\b/i.test(bodyText)) {
-        return isAsbrEnabled(bodyText);
+      const state = getAsbrState(bodyText);
+      if (state === "enabled") {
+        return true;
+      }
+      if (state === "disabled") {
+        return false;
       }
     }
 

--- a/packages/@birdcc/linter/src/rules/ospf.ts
+++ b/packages/@birdcc/linter/src/rules/ospf.ts
@@ -71,8 +71,7 @@ const getAsbrStateInBlock = (text: string): "enabled" | "disabled" | "none" => {
   const statements = splitStatements(stripNestedBlocks(text));
   for (let index = statements.length - 1; index >= 0; index -= 1) {
     const statement = statements[index] ?? "";
-    const normalized = statement.toLowerCase();
-    if (!/\basbr\b/i.test(normalized)) {
+    if (!/\basbr\b/i.test(statement)) {
       continue;
     }
 
@@ -92,8 +91,7 @@ const getStubStateInBlock = (text: string): "enabled" | "disabled" | "none" => {
   const statements = splitStatements(stripNestedBlocks(text));
   for (let index = statements.length - 1; index >= 0; index -= 1) {
     const statement = statements[index] ?? "";
-    const normalized = statement.toLowerCase();
-    if (!/\bstub\b/i.test(normalized)) {
+    if (!/\bstub\b/i.test(statement)) {
       continue;
     }
 

--- a/packages/@birdcc/linter/src/rules/ospf.ts
+++ b/packages/@birdcc/linter/src/rules/ospf.ts
@@ -15,7 +15,6 @@ interface OspfAreaSegment {
   range: SourceRange;
   hasStub?: boolean;
   hasVlink?: boolean;
-  hasAsbr?: boolean;
 }
 
 const BACKBONE_AREA_IDS = new Set(["0", "0.0.0.0"]);
@@ -24,6 +23,26 @@ const normalizeAreaId = (value: string): string => value.trim().toLowerCase();
 
 const isBackboneArea = (value: string): boolean =>
   BACKBONE_AREA_IDS.has(normalizeAreaId(value));
+
+const isAsbrEnabled = (text: string): boolean => {
+  const normalized = text.trim().toLowerCase();
+  if (!/\basbr\b/i.test(normalized)) {
+    return false;
+  }
+
+  // Disabled forms: "no asbr", "asbr no", "asbr off", "asbr false".
+  return (
+    !/^\s*no\s+asbr\b/i.test(normalized) &&
+    !/\basbr\s+(?:no|off|false)\b/i.test(normalized)
+  );
+};
+
+const hasProtocolAsbr = (
+  declaration: Parameters<typeof protocolOtherTextEntries>[0],
+): boolean =>
+  declaration.statements.some(
+    (statement) => statement.kind === "other" && isAsbrEnabled(statement.text),
+  );
 
 const parseAreaSegments = (
   text: string,
@@ -105,7 +124,6 @@ const collectAreas = (
 
       let hasStub: boolean | undefined;
       let hasVlink: boolean | undefined;
-      let hasAsbr = false;
       for (const entry of statement.entries) {
         if (entry.kind === "stub") {
           hasStub = entry.value === undefined || entry.value;
@@ -116,13 +134,6 @@ const collectAreas = (
           hasVlink = true;
           continue;
         }
-
-        if (
-          entry.kind === "other" &&
-          /^\s*(?:no\s+)?asbr\b/i.test(entry.text)
-        ) {
-          hasAsbr = !/^\s*no\s+asbr\b/i.test(entry.text);
-        }
       }
 
       return [
@@ -132,7 +143,6 @@ const collectAreas = (
           range: statement,
           hasStub,
           hasVlink,
-          hasAsbr,
         },
       ];
     },
@@ -240,6 +250,7 @@ const ospfAsbrStubAreaRule: BirdRule = ({ parsed }) => {
       continue;
     }
 
+    const protocolAsbr = hasProtocolAsbr(declaration);
     const areas = collectAreas(declaration);
     for (const area of areas) {
       if (isBackboneArea(area.areaId)) {
@@ -247,7 +258,7 @@ const ospfAsbrStubAreaRule: BirdRule = ({ parsed }) => {
       }
 
       const hasStub = area.hasStub ?? /\bstub\b/i.test(area.text);
-      const hasAsbr = area.hasAsbr ?? /\basbr\b/i.test(area.text);
+      const hasAsbr = protocolAsbr || isAsbrEnabled(area.text);
       if (!hasStub || !hasAsbr) {
         continue;
       }

--- a/packages/@birdcc/linter/src/rules/ospf.ts
+++ b/packages/@birdcc/linter/src/rules/ospf.ts
@@ -61,30 +61,69 @@ const stripNestedBlocks = (value: string): string => {
   return result;
 };
 
-const getAsbrState = (text: string): "enabled" | "disabled" | "none" => {
-  const normalized = stripComments(text).toLowerCase();
-  if (!/\basbr\b/i.test(normalized)) {
-    return "none";
+const splitStatements = (text: string): string[] => {
+  const statements: string[] = [];
+  let current = "";
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (char === ";" || char === "\n") {
+      const trimmed = current.trim();
+      if (trimmed.length > 0) {
+        statements.push(trimmed);
+      }
+      current = "";
+      continue;
+    }
+    current += char;
   }
+  const trimmed = current.trim();
+  if (trimmed.length > 0) {
+    statements.push(trimmed);
+  }
+  return statements;
+};
 
-  const isDisabled =
-    /\bno\s+asbr\b/i.test(normalized) ||
-    /\basbr\s+(?:no|off|false)\b/i.test(normalized);
+const getAsbrStateInBlock = (text: string): "enabled" | "disabled" | "none" => {
+  const statements = splitStatements(stripNestedBlocks(text));
+  for (let index = statements.length - 1; index >= 0; index -= 1) {
+    const statement = statements[index] ?? "";
+    const normalized = statement.toLowerCase();
+    if (!/\basbr\b/i.test(normalized)) {
+      continue;
+    }
 
-  return isDisabled ? "disabled" : "enabled";
+    const isDisabled =
+      /^\s*no\s+asbr\b/i.test(statement) ||
+      /\basbr\s+(?:no|off|false)\b/i.test(statement);
+
+    return isDisabled ? "disabled" : "enabled";
+  }
+  return "none";
 };
 
 const isAsbrEnabled = (text: string): boolean =>
-  getAsbrState(text) === "enabled";
+  getAsbrStateInBlock(text) === "enabled";
 
-const isStubEnabled = (text: string): boolean => {
-  const normalized = stripComments(text).toLowerCase();
-  if (!/\bstub\b/i.test(normalized)) {
-    return false;
+const getStubStateInBlock = (text: string): "enabled" | "disabled" | "none" => {
+  const statements = splitStatements(stripNestedBlocks(text));
+  for (let index = statements.length - 1; index >= 0; index -= 1) {
+    const statement = statements[index] ?? "";
+    const normalized = statement.toLowerCase();
+    if (!/\bstub\b/i.test(normalized)) {
+      continue;
+    }
+
+    const isDisabled =
+      /^\s*no\s+stub\b/i.test(statement) ||
+      /\bstub\s+(?:no|off|false)\b/i.test(statement);
+
+    return isDisabled ? "disabled" : "enabled";
   }
-
-  return !/\bstub\s+(?:no|off|false)\b/i.test(normalized);
+  return "none";
 };
+
+const isStubEnabled = (text: string): boolean =>
+  getStubStateInBlock(text) === "enabled";
 
 const hasProtocolAsbr = (
   declaration: ProtocolDeclaration,
@@ -106,7 +145,7 @@ const hasProtocolAsbr = (
           statement.kind === "other",
       );
       for (let index = asbrStatements.length - 1; index >= 0; index -= 1) {
-        const state = getAsbrState(asbrStatements[index]?.text ?? "");
+        const state = getAsbrStateInBlock(asbrStatements[index]?.text ?? "");
         if (state === "enabled") {
           return true;
         }
@@ -116,7 +155,7 @@ const hasProtocolAsbr = (
       }
     } else if (current.kind === "template") {
       const bodyText = current.bodyText ?? "";
-      const state = getAsbrState(stripNestedBlocks(bodyText));
+      const state = getAsbrStateInBlock(bodyText);
       if (state === "enabled") {
         return true;
       }
@@ -360,8 +399,7 @@ const ospfAsbrStubAreaRule: BirdRule = ({ parsed }) => {
       }
 
       const hasStub = area.hasStub ?? isStubEnabled(area.text);
-      const hasAsbr =
-        protocolAsbr || isAsbrEnabled(stripNestedBlocks(area.text));
+      const hasAsbr = protocolAsbr || isAsbrEnabled(area.text);
       if (!hasStub || !hasAsbr) {
         continue;
       }

--- a/packages/@birdcc/linter/src/rules/ospf.ts
+++ b/packages/@birdcc/linter/src/rules/ospf.ts
@@ -39,10 +39,11 @@ const stripComments = (value: string): string =>
     .trim();
 
 const stripNestedBlocks = (value: string): string => {
+  const cleaned = stripComments(value);
   let result = "";
   let depth = 0;
-  for (let index = 0; index < value.length; index += 1) {
-    const char = value[index];
+  for (let index = 0; index < cleaned.length; index += 1) {
+    const char = cleaned[index];
     if (char === "{") {
       depth += 1;
       continue;
@@ -73,6 +74,15 @@ const getAsbrState = (text: string): "enabled" | "disabled" | "none" => {
 
 const isAsbrEnabled = (text: string): boolean =>
   getAsbrState(text) === "enabled";
+
+const isStubEnabled = (text: string): boolean => {
+  const normalized = stripComments(text).toLowerCase();
+  if (!/\bstub\b/i.test(normalized)) {
+    return false;
+  }
+
+  return !/\bstub\s+(?:no|off|false)\b/i.test(normalized);
+};
 
 const hasProtocolAsbr = (
   declaration: ProtocolDeclaration,
@@ -281,7 +291,7 @@ const ospfBackboneStubRule: BirdRule = ({ parsed }) => {
     for (const area of areas) {
       if (
         !isBackboneArea(area.areaId) ||
-        !(area.hasStub ?? /\bstub\b/i.test(area.text))
+        !(area.hasStub ?? isStubEnabled(area.text))
       ) {
         continue;
       }
@@ -347,8 +357,9 @@ const ospfAsbrStubAreaRule: BirdRule = ({ parsed }) => {
         continue;
       }
 
-      const hasStub = area.hasStub ?? /\bstub\b/i.test(area.text);
-      const hasAsbr = protocolAsbr || isAsbrEnabled(area.text);
+      const hasStub = area.hasStub ?? isStubEnabled(area.text);
+      const hasAsbr =
+        protocolAsbr || isAsbrEnabled(stripNestedBlocks(area.text));
       if (!hasStub || !hasAsbr) {
         continue;
       }

--- a/packages/@birdcc/linter/src/rules/ospf.ts
+++ b/packages/@birdcc/linter/src/rules/ospf.ts
@@ -38,6 +38,26 @@ const stripComments = (value: string): string =>
     )
     .trim();
 
+const stripNestedBlocks = (value: string): string => {
+  let result = "";
+  let depth = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+    if (char === "}") {
+      depth = Math.max(0, depth - 1);
+      continue;
+    }
+    if (depth <= 1) {
+      result += char;
+    }
+  }
+  return result;
+};
+
 const getAsbrState = (text: string): "enabled" | "disabled" | "none" => {
   const normalized = stripComments(text).toLowerCase();
   if (!/\basbr\b/i.test(normalized)) {
@@ -84,7 +104,7 @@ const hasProtocolAsbr = (
       }
     } else if (current.kind === "template") {
       const bodyText = current.bodyText ?? "";
-      const state = getAsbrState(bodyText);
+      const state = getAsbrState(stripNestedBlocks(bodyText));
       if (state === "enabled") {
         return true;
       }

--- a/packages/@birdcc/linter/src/rules/ospf.ts
+++ b/packages/@birdcc/linter/src/rules/ospf.ts
@@ -107,14 +107,18 @@ const collectAreas = (
           areaId: normalizeAreaId(statement.areaId),
           text,
           range: statement,
-          hasStub: statement.entries.some(
-            (entry) =>
-              entry.kind === "stub" &&
-              (entry.value === undefined || entry.value),
-          ),
+          hasStub: statement.entries.some((entry) => entry.kind === "stub")
+            ? statement.entries.some(
+                (entry) =>
+                  entry.kind === "stub" &&
+                  (entry.value === undefined || entry.value),
+              )
+            : undefined,
           hasVlink: statement.entries.some(
             (entry) => entry.kind === "virtual-link",
-          ),
+          )
+            ? statement.entries.some((entry) => entry.kind === "virtual-link")
+            : undefined,
           hasAsbr: statement.entries.some(
             (entry) => entry.kind === "other" && /\basbr\b/i.test(entry.text),
           ),

--- a/packages/@birdcc/linter/src/rules/ospf.ts
+++ b/packages/@birdcc/linter/src/rules/ospf.ts
@@ -30,8 +30,16 @@ const normalizeAreaId = (value: string): string => value.trim().toLowerCase();
 const isBackboneArea = (value: string): boolean =>
   BACKBONE_AREA_IDS.has(normalizeAreaId(value));
 
+const stripComments = (value: string): string =>
+  value
+    .replace(
+      /"[^"\\]*(?:\\.[^"\\]*)*"|'[^'\\]*(?:\\.[^'\\]*)*'|(#.*|\/\*[\s\S]*?\*\/)/gu,
+      (match, group) => (group ? "" : match),
+    )
+    .trim();
+
 const isAsbrEnabled = (text: string): boolean => {
-  const normalized = text.trim().toLowerCase();
+  const normalized = stripComments(text).toLowerCase();
   if (!/\basbr\b/i.test(normalized)) {
     return false;
   }

--- a/packages/@birdcc/linter/src/rules/ospf.ts
+++ b/packages/@birdcc/linter/src/rules/ospf.ts
@@ -1,5 +1,11 @@
 import type { BirdDiagnostic } from "@birdcc/core";
-import type { SourceRange } from "@birdcc/parser";
+import type {
+  ParsedBirdDocument,
+  ProtocolDeclaration,
+  ProtocolStatement,
+  SourceRange,
+  TemplateDeclaration,
+} from "@birdcc/parser";
 import {
   createProtocolDiagnostic,
   createRuleDiagnostic,
@@ -38,11 +44,55 @@ const isAsbrEnabled = (text: string): boolean => {
 };
 
 const hasProtocolAsbr = (
-  declaration: Parameters<typeof protocolOtherTextEntries>[0],
-): boolean =>
-  declaration.statements.some(
-    (statement) => statement.kind === "other" && isAsbrEnabled(statement.text),
-  );
+  declaration: ProtocolDeclaration,
+  parsed: ParsedBirdDocument,
+): boolean => {
+  const declarations = parsed.program.declarations;
+  const visited = new Set<string>();
+  let current: ProtocolDeclaration | TemplateDeclaration | undefined =
+    declaration;
+  let depth = 0;
+  const maxDepth = 10;
+
+  while (current && depth < maxDepth) {
+    if (current.kind === "protocol") {
+      const asbrStatements = current.statements.filter(
+        (
+          statement,
+        ): statement is Extract<ProtocolStatement, { kind: "other" }> =>
+          statement.kind === "other" && /\basbr\b/i.test(statement.text),
+      );
+      if (asbrStatements.length > 0) {
+        const lastStatement = asbrStatements[asbrStatements.length - 1];
+        return isAsbrEnabled(lastStatement.text);
+      }
+    } else if (current.kind === "template") {
+      const bodyText = current.bodyText ?? "";
+      if (/\basbr\b/i.test(bodyText)) {
+        return isAsbrEnabled(bodyText);
+      }
+    }
+
+    const templateName = current.fromTemplate;
+    if (!templateName) {
+      break;
+    }
+
+    const key = templateName.toLowerCase();
+    if (visited.has(key)) {
+      break;
+    }
+    visited.add(key);
+
+    current = declarations.find(
+      (decl): decl is TemplateDeclaration =>
+        decl.kind === "template" && decl.name.toLowerCase() === key,
+    );
+    depth += 1;
+  }
+
+  return false;
+};
 
 const parseAreaSegments = (
   text: string,
@@ -250,7 +300,7 @@ const ospfAsbrStubAreaRule: BirdRule = ({ parsed }) => {
       continue;
     }
 
-    const protocolAsbr = hasProtocolAsbr(declaration);
+    const protocolAsbr = hasProtocolAsbr(declaration, parsed);
     const areas = collectAreas(declaration);
     for (const area of areas) {
       if (isBackboneArea(area.areaId)) {

--- a/packages/@birdcc/linter/src/rules/ospf.ts
+++ b/packages/@birdcc/linter/src/rules/ospf.ts
@@ -102,26 +102,37 @@ const collectAreas = (
       const text = statement.entries
         .map((entry) => (entry.kind === "other" ? entry.text : entry.kind))
         .join(" ");
+
+      let hasStub: boolean | undefined;
+      let hasVlink: boolean | undefined;
+      let hasAsbr = false;
+      for (const entry of statement.entries) {
+        if (entry.kind === "stub") {
+          hasStub = entry.value === undefined || entry.value;
+          continue;
+        }
+
+        if (entry.kind === "virtual-link") {
+          hasVlink = true;
+          continue;
+        }
+
+        if (
+          entry.kind === "other" &&
+          /^\s*(?:no\s+)?asbr\b/i.test(entry.text)
+        ) {
+          hasAsbr = !/^\s*no\s+asbr\b/i.test(entry.text);
+        }
+      }
+
       return [
         {
           areaId: normalizeAreaId(statement.areaId),
           text,
           range: statement,
-          hasStub: statement.entries.some((entry) => entry.kind === "stub")
-            ? statement.entries.some(
-                (entry) =>
-                  entry.kind === "stub" &&
-                  (entry.value === undefined || entry.value),
-              )
-            : undefined,
-          hasVlink: statement.entries.some(
-            (entry) => entry.kind === "virtual-link",
-          )
-            ? statement.entries.some((entry) => entry.kind === "virtual-link")
-            : undefined,
-          hasAsbr: statement.entries.some(
-            (entry) => entry.kind === "other" && /\basbr\b/i.test(entry.text),
-          ),
+          hasStub,
+          hasVlink,
+          hasAsbr,
         },
       ];
     },

--- a/packages/@birdcc/linter/src/rules/ospf.ts
+++ b/packages/@birdcc/linter/src/rules/ospf.ts
@@ -61,27 +61,11 @@ const stripNestedBlocks = (value: string): string => {
   return result;
 };
 
-const splitStatements = (text: string): string[] => {
-  const statements: string[] = [];
-  let current = "";
-  for (let index = 0; index < text.length; index += 1) {
-    const char = text[index];
-    if (char === ";" || char === "\n") {
-      const trimmed = current.trim();
-      if (trimmed.length > 0) {
-        statements.push(trimmed);
-      }
-      current = "";
-      continue;
-    }
-    current += char;
-  }
-  const trimmed = current.trim();
-  if (trimmed.length > 0) {
-    statements.push(trimmed);
-  }
-  return statements;
-};
+const splitStatements = (text: string): string[] =>
+  text
+    .split(/[;\n]+/u)
+    .map((statement) => statement.trim())
+    .filter((statement) => statement.length > 0);
 
 const getAsbrStateInBlock = (text: string): "enabled" | "disabled" | "none" => {
   const statements = splitStatements(stripNestedBlocks(text));

--- a/packages/@birdcc/linter/test/linter.bgp-ospf.test.ts
+++ b/packages/@birdcc/linter/test/linter.bgp-ospf.test.ts
@@ -305,6 +305,21 @@ describe("@birdcc/linter bgp+ospf rules", () => {
     expect(codes).not.toContain("ospf/asbr-stub-area");
   });
 
+  it("hits ospf/asbr-stub-area when ASBR is inherited from template", async () => {
+    const codes = await codesOf(`
+      template ospf base_tpl {
+        asbr;
+      }
+      protocol ospf core from base_tpl {
+        area 1 {
+          stub;
+        };
+      }
+    `);
+
+    expect(codes).toContain("ospf/asbr-stub-area");
+  });
+
   it("accepts area 0.0.0.0 as backbone area id", async () => {
     const codes = await codesOf(`
       protocol ospf core {

--- a/packages/@birdcc/linter/test/linter.bgp-ospf.test.ts
+++ b/packages/@birdcc/linter/test/linter.bgp-ospf.test.ts
@@ -346,6 +346,21 @@ describe("@birdcc/linter bgp+ospf rules", () => {
     expect(codes).not.toContain("ospf/asbr-stub-area");
   });
 
+  it("ignores ASBR in nested block descriptions", async () => {
+    const codes = await codesOf(`
+      protocol ospf core {
+        area 1 {
+          interface "eth0" {
+            description "This is our ASBR router";
+          };
+          stub;
+        };
+      }
+    `);
+
+    expect(codes).not.toContain("ospf/asbr-stub-area");
+  });
+
   it("accepts area 0.0.0.0 as backbone area id", async () => {
     const codes = await codesOf(`
       protocol ospf core {

--- a/packages/@birdcc/linter/test/linter.bgp-ospf.test.ts
+++ b/packages/@birdcc/linter/test/linter.bgp-ospf.test.ts
@@ -211,6 +211,19 @@ describe("@birdcc/linter bgp+ospf rules", () => {
     expect(codes).toContain("bgp/timer-invalid");
   });
 
+  it("hits bgp/timer-invalid when keepalive is non-zero while hold is disabled", async () => {
+    const codes = await codesOf(`
+      protocol bgp edge {
+        local as 65001;
+        neighbor 192.0.2.1 as 65001;
+        hold 0;
+        keepalive 10;
+      }
+    `);
+
+    expect(codes).toContain("bgp/timer-invalid");
+  });
+
   it("hits ospf/missing-area", async () => {
     const codes = await codesOf(`
       protocol ospf core {
@@ -318,6 +331,19 @@ describe("@birdcc/linter bgp+ospf rules", () => {
     `);
 
     expect(codes).toContain("ospf/asbr-stub-area");
+  });
+
+  it("ignores comments when detecting disabled ASBR", async () => {
+    const codes = await codesOf(`
+      protocol ospf core {
+        area 1 {
+          asbr no; # disabled
+          stub;
+        };
+      }
+    `);
+
+    expect(codes).not.toContain("ospf/asbr-stub-area");
   });
 
   it("accepts area 0.0.0.0 as backbone area id", async () => {

--- a/packages/@birdcc/linter/test/linter.bgp-ospf.test.ts
+++ b/packages/@birdcc/linter/test/linter.bgp-ospf.test.ts
@@ -282,14 +282,27 @@ describe("@birdcc/linter bgp+ospf rules", () => {
   it("hits ospf/asbr-stub-area", async () => {
     const codes = await codesOf(`
       protocol ospf core {
+        asbr;
         area 1 {
           stub;
-          asbr on;
         };
       }
     `);
 
     expect(codes).toContain("ospf/asbr-stub-area");
+  });
+
+  it("does not hit ospf/asbr-stub-area when ASBR is disabled at protocol level", async () => {
+    const codes = await codesOf(`
+      protocol ospf core {
+        asbr no;
+        area 1 {
+          stub;
+        };
+      }
+    `);
+
+    expect(codes).not.toContain("ospf/asbr-stub-area");
   });
 
   it("accepts area 0.0.0.0 as backbone area id", async () => {

--- a/packages/@birdcc/parser/src/declarations/basic.ts
+++ b/packages/@birdcc/parser/src/declarations/basic.ts
@@ -378,6 +378,7 @@ export const parseTemplateDeclaration = (
       : inferredFromTemplate
         ? declarationRange
         : undefined,
+    bodyText: isPresentNode(bodyNode) ? textOf(bodyNode, source) : undefined,
     ...declarationRange,
   };
 };

--- a/packages/@birdcc/parser/src/declarations/protocol.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol.ts
@@ -2844,7 +2844,7 @@ const parseBfdProfileTextStatement = (
     return undefined;
   }
 
-  const patternText = rest.slice(0, rest.indexOf(bodyText)).trim();
+  const patternText = rest.slice(0, bodyMatch.index).trim();
   const patternMatches = [...patternText.matchAll(/"[^"]+"|'[^']+'|\S+/gu)];
   const patterns = patternMatches.map((match) => stripQuotedText(match[0]));
   const patternRanges = patternMatches.map((match) => tokenRange(match[0]));
@@ -4196,9 +4196,7 @@ const parseBabelInterfaceTextStatement = (
 
   const bodyMatch = rest.match(/\{[\s\S]*\}$/u);
   const bodyText = bodyMatch?.[0];
-  const patternText = bodyText
-    ? rest.slice(0, rest.indexOf(bodyText)).trim()
-    : rest;
+  const patternText = bodyMatch ? rest.slice(0, bodyMatch.index).trim() : rest;
   const patternMatches = [...patternText.matchAll(/"[^"]+"|'[^']+'|\S+/gu)];
   if (patternMatches.length === 0) {
     return undefined;

--- a/packages/@birdcc/parser/src/declarations/protocol.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol.ts
@@ -2839,10 +2839,10 @@ const parseBfdProfileTextStatement = (
   const profileType = profileMatch[1].toLowerCase() as "interface" | "multihop";
   const rest = profileMatch[2].trim();
   const bodyMatch = rest.match(/\{[\s\S]*\}$/u);
-  const bodyText = bodyMatch?.[0];
-  if (!bodyText) {
+  if (!bodyMatch) {
     return undefined;
   }
+  const bodyText = bodyMatch[0];
 
   const patternText = rest.slice(0, bodyMatch.index).trim();
   const patternMatches = [...patternText.matchAll(/"[^"]+"|'[^']+'|\S+/gu)];

--- a/packages/@birdcc/parser/src/declarations/protocol.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol.ts
@@ -4196,21 +4196,26 @@ const parseBabelInterfaceTextStatement = (
 
   const bodyMatch = rest.match(/\{[\s\S]*\}$/u);
   const bodyText = bodyMatch?.[0];
-  if (!bodyText) {
+  const patternText = bodyText
+    ? rest.slice(0, rest.indexOf(bodyText)).trim()
+    : rest;
+  const patternMatches = [...patternText.matchAll(/"[^"]+"|'[^']+'|\S+/gu)];
+  if (patternMatches.length === 0) {
     return undefined;
   }
 
-  const patternText = rest.slice(0, rest.indexOf(bodyText)).trim();
-  const patternMatches = [...patternText.matchAll(/"[^"]+"|'[^']+'|\S+/gu)];
   const patterns = patternMatches.map((match) => stripQuotedText(match[0]));
   const patternRanges = patternMatches.map((match) => tokenRange(match[0]));
-  const bodyRange = tokenRange(bodyText);
+  const bodyRange = bodyText ? tokenRange(bodyText) : undefined;
 
   return {
     kind: "babel-interface",
     patterns,
     patternRanges,
-    entries: parseBabelInterfaceEntries(bodyText, bodyRange, tokenRange),
+    entries:
+      bodyText && bodyRange
+        ? parseBabelInterfaceEntries(bodyText, bodyRange, tokenRange)
+        : [],
     bodyText,
     bodyRange,
     ...statementRange,

--- a/packages/@birdcc/parser/src/issues.ts
+++ b/packages/@birdcc/parser/src/issues.ts
@@ -167,7 +167,7 @@ const RPKI_LOCAL_ADDRESS = /^\s*local\s+address\s+\S+\s*;\s*$/i;
 const ALLOW_LOCAL_AS = /^\s*allow\s+local\s+as\s*;\s*$/i;
 const BFD_ACCEPT = /^\s*accept(?:\s+(?:ipv4|ipv6|direct|multihop))*\s*;\s*$/i;
 const BFD_NEIGHBOR =
-  /^\s*neighbor\s+\S+(?:\s+(?:%\s+\S+|dev\s+(?:"[^"]+"|'[^']+'|\S+)|local\s+\S+|multihop(?:\s+\S+)?))*\s*;\s*$/i;
+  /^\s*neighbor\s+\S+(?:\s+(?:%\s+\S+|dev\s+(?:"[^"]+"|'[^']+'|\S+)|local\s+\S+|multihop(?:\s+\S+)?))*\s*;?\s*$/i;
 const BFD_PROFILE_HEADER = /^\s*(?:interface\b.+|multihop\s*)\{\s*$/i;
 const BFD_PROFILE_ITEM =
   /^\s*(?:interval|min\s+rx\s+interval|min\s+tx\s+interval|idle\s+tx\s+interval|multiplier|passive|authentication|password|graceful)\b.*;\s*$/i;

--- a/packages/@birdcc/parser/src/types.ts
+++ b/packages/@birdcc/parser/src/types.ts
@@ -2137,6 +2137,7 @@ export interface TemplateDeclaration extends DeclarationBase {
   nameRange: SourceRange;
   fromTemplate?: string;
   fromTemplateRange?: SourceRange;
+  bodyText?: string;
 }
 
 export interface ExtractedLiteral extends SourceRange {

--- a/packages/@birdcc/parser/src/types.ts
+++ b/packages/@birdcc/parser/src/types.ts
@@ -1555,8 +1555,8 @@ export interface BabelInterfaceStatement extends StatementBase {
   patterns: string[];
   patternRanges: SourceRange[];
   entries: BabelInterfaceEntry[];
-  bodyText: string;
-  bodyRange: SourceRange;
+  bodyText?: string;
+  bodyRange?: SourceRange;
 }
 
 interface RadvInterfaceEntryBase extends SourceRange {

--- a/packages/@birdcc/parser/test/parser.test.ts
+++ b/packages/@birdcc/parser/test/parser.test.ts
@@ -3042,6 +3042,33 @@ describe("@birdcc/parser tree-sitter", () => {
     }
   });
 
+  it("parses Babel interface without a body", async () => {
+    const parsed = await parseBirdConfig(`
+      protocol babel edge {
+        interface "eth0";
+      }
+    `);
+
+    expect(parsed.issues).toHaveLength(0);
+
+    const protocol = parsed.program.declarations.find(
+      (item) => item.kind === "protocol",
+    );
+    expect(protocol).toBeDefined();
+    if (protocol?.kind === "protocol") {
+      const iface = protocol.statements.find(
+        (item) => item.kind === "babel-interface",
+      );
+      expect(iface).toEqual(
+        expect.objectContaining({
+          kind: "babel-interface",
+          patterns: ["eth0"],
+          entries: [],
+        }),
+      );
+    }
+  });
+
   it("preserves RADV interface body entries", async () => {
     const sample = `
       protocol radv ra1 {


### PR DESCRIPTION
## Summary
This PR expands parser coverage for a wide range of routing protocols (MRT, BMP, BFD, VPN, Babel, EVPN, bridge, pipe, static) and introduces core OSPF/RIP protocol support, alongside upstream linter and LSP adaptations.

## Depends on
- #140

## Changes

### Miscellaneous Protocol Options (`@birdcc/parser`)
- `feat(parser)`: Parse MRT protocol options
- `feat(parser)`: Parse aggregator protocol options
- `feat(parser)`: Parse BMP protocol options
- `feat(parser)`: Parse BFD protocol options
- `feat(parser)`: Parse VPN protocol options
- `feat(parser)`: Parse Babel protocol options
- `feat(parser)`: Parse EVPN nested options
- `feat(parser)`: Parse bridge protocol options
- `test(parser)`: Cover bridge dynamic attributes
- `feat(parser)`: Parse pipe protocol options
- `fix(parser)`: Parse static protocol options
- `feat(parser)`: Parse static route options (early)
- `feat(parser)`: Parse graceful restart wait
- `feat(parser)`: Parse hostname override

### OSPF Protocol Support (`@birdcc/parser`)
- `feat(parser)`: Parse OSPF protocol options
- `feat(parser)`: Parse OSPF area options
- `feat(parser)`: Parse OSPF area prefix lists
- `feat(parser)`: Parse OSPF area interface options
- `feat(parser)`: Parse OSPF interface variants
- `feat(parser)`: Parse OSPF virtual links

### BGP Additional Options (`@birdcc/parser`)
- `feat(parser)`: Parse BGP channel path options
- `feat(parser)`: Parse BGP export settle time
- `feat(parser)`: Parse BGP capability options
- `feat(parser)`: Parse BGP authentication options
- `feat(parser)`: Parse BGP channel requirements
- `feat(parser)`: Parse BGP TCP-AO keys

### RIP Protocol Support (`@birdcc/parser`)
- `feat(parser)`: Parse RIP protocol options
- `feat(parser)`: Parse RIP interface blocks
- `feat(parser)`: Parse RIP interface options

### Upstream Adaptations
- `fix(linter)`: Read structured BGP and OSPF statements (`@birdcc/linter`)
- `feat(lsp)`: Surface structured top-level declarations (`@birdcc/lsp`)

## Affected Packages
- `@birdcc/parser`
- `@birdcc/linter`
- `@birdcc/lsp`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bird-chinese-community/codesmith/BIRD-LSP/pr/141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783696971&installation_id=136501088&pr_number=141&repository=bird-chinese-community%2FBIRD-LSP&return_to=https%3A%2F%2Fgithub.com%2Fbird-chinese-community%2FBIRD-LSP%2Fpull%2F141&signature=637224a451802b89942a09599ffa064defe7d29f4236ac15caa2396ed493b77e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->