### PR TITLE
feat(parser): Kernel/direct/perf/static routing and full RADV protocol support

### DIFF
--- a/packages/@birdcc/parser/src/declarations/filter.ts
+++ b/packages/@birdcc/parser/src/declarations/filter.ts
@@ -365,10 +365,21 @@ const collectLiteralsAndMatches = (
     return matched?.[0] ?? null;
   };
 
-  const collectNode = (node: SyntaxNode): void => {
-    const namedChildren = node.namedChildren;
+  const collectNode = (rootNode: SyntaxNode): void => {
+    type Frame = { node: SyntaxNode; index: number };
+    const stack: Frame[] = [{ node: rootNode, index: 0 }];
 
-    for (let index = 0; index < namedChildren.length; index += 1) {
+    while (stack.length > 0) {
+      const frame = stack[stack.length - 1];
+      const { node, index } = frame;
+      const namedChildren = node.namedChildren;
+
+      if (index >= namedChildren.length) {
+        stack.pop();
+        continue;
+      }
+
+      frame.index += 1;
       const current = namedChildren[index];
       if (!current) {
         continue;
@@ -479,7 +490,9 @@ const collectLiteralsAndMatches = (
         });
       }
 
-      collectNode(current);
+      if (current.namedChildren.length > 0) {
+        stack.push({ node: current, index: 0 });
+      }
     }
   };
 

--- a/packages/@birdcc/parser/src/declarations/filter.ts
+++ b/packages/@birdcc/parser/src/declarations/filter.ts
@@ -66,11 +66,12 @@ const parseControlStatements = (
   const statements: FilterBodyStatement[] = [];
   const bodyRange = toRange(bodyNode, source);
   const bodyText = textOf(bodyNode, source);
-  const tokenTexts = bodyNode.namedChildren.map((node) =>
+  const bodyChildren = bodyNode.namedChildren;
+  const tokenTexts = bodyChildren.map((node) =>
     textOf(node, source).toLowerCase(),
   );
 
-  for (const statementNode of bodyNode.namedChildren) {
+  for (const statementNode of bodyChildren) {
     const statementRange = toRange(statementNode, source);
     const text = textOf(statementNode, source).trim();
     const lowered = text.toLowerCase();
@@ -366,21 +367,20 @@ const collectLiteralsAndMatches = (
   };
 
   const collectNode = (rootNode: SyntaxNode): void => {
-    type Frame = { node: SyntaxNode; index: number };
-    const stack: Frame[] = [{ node: rootNode, index: 0 }];
+    type Frame = { children: SyntaxNode[]; index: number };
+    const stack: Frame[] = [{ children: rootNode.namedChildren, index: 0 }];
 
     while (stack.length > 0) {
       const frame = stack[stack.length - 1];
-      const { node, index } = frame;
-      const namedChildren = node.namedChildren;
+      const { index, children } = frame;
 
-      if (index >= namedChildren.length) {
+      if (index >= children.length) {
         stack.pop();
         continue;
       }
 
       frame.index += 1;
-      const current = namedChildren[index];
+      const current = children[index];
       if (!current) {
         continue;
       }
@@ -416,7 +416,7 @@ const collectLiteralsAndMatches = (
             });
           }
         } else {
-          const nextNode = namedChildren[index + 1];
+          const nextNode = children[index + 1];
           const nextText = nextNode ? textOf(nextNode, source) : "";
           const nextSuffix = nextNode ? extractPrefixSuffix(nextText) : null;
 
@@ -463,8 +463,8 @@ const collectLiteralsAndMatches = (
       }
 
       if (currentText.trim() === "~") {
-        const leftNode = namedChildren[index - 1];
-        const immediateRightNode = namedChildren[index + 1];
+        const leftNode = children[index - 1];
+        const immediateRightNode = children[index + 1];
 
         if (!leftNode || !immediateRightNode) {
           continue;
@@ -474,7 +474,7 @@ const collectLiteralsAndMatches = (
         const immediateRightText = textOf(immediateRightNode, source).trim();
         const rightNode =
           immediateRightText === "["
-            ? (namedChildren[index + 2] ?? immediateRightNode)
+            ? (children[index + 2] ?? immediateRightNode)
             : immediateRightNode;
         const rightText = textOf(rightNode, source).trim();
 
@@ -490,8 +490,11 @@ const collectLiteralsAndMatches = (
         });
       }
 
-      if (current.namedChildren.length > 0) {
-        stack.push({ node: current, index: 0 });
+      if (current.namedChildCount > 0) {
+        stack.push({
+          children: current.namedChildren,
+          index: 0,
+        });
       }
     }
   };

--- a/packages/@birdcc/parser/src/declarations/protocol-radv.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol-radv.ts
@@ -416,7 +416,9 @@ export const parseRadvInterfaceTextStatement = (
   statementRange: SourceRange,
   tokenRange: TokenRange,
 ): ProtocolStatement | undefined => {
-  const trimmed = statementText.trim().replace(/;\s*$/u, "");
+  const trimmed = stripTrailingComment(statementText)
+    .trim()
+    .replace(/;\s*$/u, "");
   const interfaceMatch = trimmed.match(/^interface\b(.*)$/isu);
   const rest = (interfaceMatch?.[1] ?? "").trim();
   if (!rest) {
@@ -455,7 +457,9 @@ export const parseRadvOptionTextStatement = (
   statementRange: SourceRange,
   tokenRange: TokenRange,
 ): ProtocolStatement | undefined => {
-  const trimmed = statementText.trim().replace(/;\s*$/u, "");
+  const trimmed = stripTrailingComment(statementText)
+    .trim()
+    .replace(/;\s*$/u, "");
   const propagateRoutesMatch = trimmed.match(/^propagate\s+routes\s+(\S+)$/iu);
   if (propagateRoutesMatch?.[1]) {
     const valueText = propagateRoutesMatch[1];
@@ -518,7 +522,9 @@ export const parseRadvDnsTextStatement = (
   statementRange: SourceRange,
   tokenRange: TokenRange,
 ): ProtocolStatement | undefined => {
-  const trimmed = statementText.trim().replace(/;\s*$/u, "");
+  const trimmed = stripTrailingComment(statementText)
+    .trim()
+    .replace(/;\s*$/u, "");
   const dnsBlockMatch = trimmed.match(/^(rdnss|dnssl)\s+(\{[\s\S]*\})$/iu);
   if (dnsBlockMatch?.[1] && dnsBlockMatch[2]) {
     const block = dnsBlockMatch[1].toLowerCase() as "rdnss" | "dnssl";
@@ -555,7 +561,9 @@ export const parseRadvCustomOptionTextStatement = (
   statementRange: SourceRange,
   tokenRange: TokenRange,
 ): ProtocolStatement | undefined => {
-  const trimmed = statementText.trim().replace(/;\s*$/u, "");
+  const trimmed = stripTrailingComment(statementText)
+    .trim()
+    .replace(/;\s*$/u, "");
   const customOption = parseRadvCustomOptionParts(trimmed, tokenRange);
   if (!customOption) {
     return undefined;

--- a/packages/@birdcc/parser/src/declarations/protocol-radv.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol-radv.ts
@@ -11,6 +11,11 @@ const stripTrailingComment = (value: string): string => {
   let inDoubleQuote = false;
   for (let index = 0; index < value.length; index += 1) {
     const char = value[index];
+    if (char === "\\") {
+      index += 1;
+      continue;
+    }
+
     if (char === '"' && !inSingleQuote) {
       inDoubleQuote = !inDoubleQuote;
       continue;

--- a/packages/@birdcc/parser/src/declarations/protocol-radv.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol-radv.ts
@@ -416,21 +416,25 @@ export const parseRadvInterfaceTextStatement = (
   statementRange: SourceRange,
   tokenRange: TokenRange,
 ): ProtocolStatement | undefined => {
-  const trimmed = stripTrailingComment(statementText)
-    .trim()
-    .replace(/;\s*$/u, "");
+  const trimmed = statementText.trim();
   const interfaceMatch = trimmed.match(/^interface\b(.*)$/isu);
   const rest = (interfaceMatch?.[1] ?? "").trim();
   if (!rest) {
     return undefined;
   }
 
-  const bodyMatch = rest.match(/\{[\s\S]*\}$/u);
+  const cleanedRest = rest
+    .replace(/\s*;?\s*(?:#.*|\/\/.*|\/[\s\S]*?\*\/)?\s*$/u, "")
+    .trim();
+  const bodyMatch = cleanedRest.match(/\{[\s\S]*\}$/u);
   const bodyText = bodyMatch?.[0];
   const rawPatternText = bodyText
-    ? rest.slice(0, rest.indexOf(bodyText)).trim()
-    : rest;
-  const patternText = stripTrailingComment(rawPatternText);
+    ? cleanedRest.slice(0, cleanedRest.indexOf(bodyText)).trim()
+    : cleanedRest;
+  const patternText = stripTrailingComment(rawPatternText).replace(
+    /;\s*$/u,
+    "",
+  );
   const patternMatches = [
     ...patternText.matchAll(/"[^"]+"|'[^']+'|,|[^,\s]+/gu),
   ].filter((match) => match[0] !== ",");
@@ -457,10 +461,9 @@ export const parseRadvOptionTextStatement = (
   statementRange: SourceRange,
   tokenRange: TokenRange,
 ): ProtocolStatement | undefined => {
-  const trimmed = stripTrailingComment(statementText)
-    .trim()
-    .replace(/;\s*$/u, "");
-  const propagateRoutesMatch = trimmed.match(/^propagate\s+routes\s+(\S+)$/iu);
+  const trimmed = statementText.trim().replace(/;\s*$/u, "");
+  const cleaned = stripTrailingComment(trimmed);
+  const propagateRoutesMatch = cleaned.match(/^propagate\s+routes\s+(\S+)$/iu);
   if (propagateRoutesMatch?.[1]) {
     const valueText = propagateRoutesMatch[1];
     return {
@@ -473,7 +476,7 @@ export const parseRadvOptionTextStatement = (
     };
   }
 
-  const triggerMatch = trimmed.match(/^trigger\s+(\S+)$/iu);
+  const triggerMatch = cleaned.match(/^trigger\s+(\S+)$/iu);
   if (triggerMatch?.[1]) {
     const prefix = triggerMatch[1];
     return {
@@ -492,15 +495,15 @@ export const parseRadvPrefixTextStatement = (
   statementRange: SourceRange,
   tokenRange: TokenRange,
 ): ProtocolStatement | undefined => {
-  const trimmed = stripTrailingComment(statementText)
-    .trim()
-    .replace(/;\s*$/u, "");
-  const prefixMatch = trimmed.match(/^prefix\s+(\S+)(?:\s+(\{[\s\S]*\}))?$/iu);
+  const trimmed = statementText.trim();
+  const prefixMatch = trimmed.match(
+    /^prefix\s+(\S+)(?:\s+(\{[\s\S]*\}))?\s*(?:;?\s*(?:#.*|\/\/.*|\/[\s\S]*?\*\/)?\s*)?$/iu,
+  );
   if (!prefixMatch?.[1]) {
     return undefined;
   }
 
-  const prefix = prefixMatch[1];
+  const prefix = stripTrailingComment(prefixMatch[1]).replace(/;\s*$/u, "");
   const bodyText = prefixMatch[2];
   const bodyRange = bodyText ? tokenRange(bodyText) : undefined;
   return {
@@ -522,10 +525,10 @@ export const parseRadvDnsTextStatement = (
   statementRange: SourceRange,
   tokenRange: TokenRange,
 ): ProtocolStatement | undefined => {
-  const trimmed = stripTrailingComment(statementText)
-    .trim()
-    .replace(/;\s*$/u, "");
-  const dnsBlockMatch = trimmed.match(/^(rdnss|dnssl)\s+(\{[\s\S]*\})$/iu);
+  const trimmed = statementText.trim();
+  const dnsBlockMatch = trimmed.match(
+    /^(rdnss|dnssl)\s+(\{[\s\S]*\})\s*(?:;?\s*(?:#.*|\/\/.*|\/[\s\S]*?\*\/)?\s*)?$/iu,
+  );
   if (dnsBlockMatch?.[1] && dnsBlockMatch[2]) {
     const block = dnsBlockMatch[1].toLowerCase() as "rdnss" | "dnssl";
     const bodyText = dnsBlockMatch[2];
@@ -539,7 +542,8 @@ export const parseRadvDnsTextStatement = (
     };
   }
 
-  const dnsShorthandMatch = trimmed.match(
+  const cleaned = stripTrailingComment(trimmed).replace(/;\s*$/u, "");
+  const dnsShorthandMatch = cleaned.match(
     /^(rdnss|dnssl)\s+(\S+|"[^"]+"|'[^']+')$/iu,
   );
   if (!dnsShorthandMatch?.[1] || !dnsShorthandMatch[2]) {
@@ -561,10 +565,7 @@ export const parseRadvCustomOptionTextStatement = (
   statementRange: SourceRange,
   tokenRange: TokenRange,
 ): ProtocolStatement | undefined => {
-  const trimmed = stripTrailingComment(statementText)
-    .trim()
-    .replace(/;\s*$/u, "");
-  const customOption = parseRadvCustomOptionParts(trimmed, tokenRange);
+  const customOption = parseRadvCustomOptionParts(statementText, tokenRange);
   if (!customOption) {
     return undefined;
   }

--- a/packages/@birdcc/parser/src/declarations/protocol-radv.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol-radv.ts
@@ -1,4 +1,5 @@
 import type { ProtocolStatement, SourceRange } from "../types.js";
+import { splitTopLevelStatements } from "./shared.js";
 
 type TokenRange = (token: string) => SourceRange;
 
@@ -19,37 +20,6 @@ const parseBoolToken = (value: string | undefined): boolean | undefined => {
   }
 
   return undefined;
-};
-
-const splitTopLevelStatements = (body: string): string[] => {
-  const statements: string[] = [];
-  let depth = 0;
-  let start = 0;
-
-  for (let index = 0; index < body.length; index += 1) {
-    const char = body[index];
-    if (char === "{") {
-      depth += 1;
-      continue;
-    }
-
-    if (char === "}") {
-      depth = Math.max(0, depth - 1);
-      continue;
-    }
-
-    if (char === ";" && depth === 0) {
-      statements.push(body.slice(start, index));
-      start = index + 1;
-    }
-  }
-
-  const tail = body.slice(start).trim();
-  if (tail.length > 0) {
-    statements.push(tail);
-  }
-
-  return statements;
 };
 
 const parseRadvCustomOptionParts = (

--- a/packages/@birdcc/parser/src/declarations/protocol-radv.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol-radv.ts
@@ -9,7 +9,7 @@ const stripQuotedText = (value: string): string =>
 const stripTrailingComment = (value: string): string =>
   value
     .replace(
-      /"[^"\\]*(?:\\.[^"\\]*)*"|'[^'\\]*(?:\\.[^'\\]*)*'|(#.*|\/\*[\s\S]*?\*\/)/gu,
+      /"[^"\\]*(?:\\.[^"\\]*)*"|'[^'\\]*(?:\\.[^'\\]*)*'|(#.*|\/\/.*|\/\*[\s\S]*?\*\/)/gu,
       (match, group) => (group ? "" : match),
     )
     .trim();
@@ -41,7 +41,8 @@ const parseRadvCustomOptionParts = (
       valueRange: SourceRange;
     }
   | undefined => {
-  const customOptionMatch = statementText.match(
+  const cleaned = stripTrailingComment(statementText).replace(/;\s*$/u, "");
+  const customOptionMatch = cleaned.match(
     /^custom\s+option\s+type\s+(.+?)\s+value\s+(.+)$/iu,
   );
   if (!customOptionMatch || !customOptionMatch[1] || !customOptionMatch[2]) {

--- a/packages/@birdcc/parser/src/declarations/protocol-radv.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol-radv.ts
@@ -6,35 +6,13 @@ type TokenRange = (token: string) => SourceRange;
 const stripQuotedText = (value: string): string =>
   value.replace(/^(['"])(.*)\1$/u, "$2");
 
-const stripTrailingComment = (value: string): string => {
-  let inSingleQuote = false;
-  let inDoubleQuote = false;
-  for (let index = 0; index < value.length; index += 1) {
-    const char = value[index];
-    if (char === "\\") {
-      index += 1;
-      continue;
-    }
-
-    if (char === '"' && !inSingleQuote) {
-      inDoubleQuote = !inDoubleQuote;
-      continue;
-    }
-
-    if (char === "'" && !inDoubleQuote) {
-      inSingleQuote = !inSingleQuote;
-      continue;
-    }
-
-    if (!inSingleQuote && !inDoubleQuote) {
-      if (char === "#" || (char === "/" && value[index + 1] === "/")) {
-        return value.slice(0, index);
-      }
-    }
-  }
-
-  return value;
-};
+const stripTrailingComment = (value: string): string =>
+  value
+    .replace(
+      /"[^"\\]*(?:\\.[^"\\]*)*"|'[^'\\]*(?:\\.[^'\\]*)*'|(#.*|\/\*[\s\S]*?\*\/)/gu,
+      (match, group) => (group ? "" : match),
+    )
+    .trim();
 
 const parseBoolToken = (value: string | undefined): boolean | undefined => {
   if (!value) {
@@ -442,16 +420,17 @@ export const parseRadvInterfaceTextStatement = (
 ): ProtocolStatement | undefined => {
   const trimmed = statementText.trim().replace(/;\s*$/u, "");
   const interfaceMatch = trimmed.match(/^interface\b(.*)$/isu);
-  const rest = stripTrailingComment((interfaceMatch?.[1] ?? "").trim()).trim();
+  const rest = (interfaceMatch?.[1] ?? "").trim();
   if (!rest) {
     return undefined;
   }
 
   const bodyMatch = rest.match(/\{[\s\S]*\}$/u);
   const bodyText = bodyMatch?.[0];
-  const patternText = bodyText
+  const rawPatternText = bodyText
     ? rest.slice(0, rest.indexOf(bodyText)).trim()
     : rest;
+  const patternText = stripTrailingComment(rawPatternText);
   const patternMatches = [
     ...patternText.matchAll(/"[^"]+"|'[^']+'|,|[^,\s]+/gu),
   ].filter((match) => match[0] !== ",");
@@ -511,7 +490,9 @@ export const parseRadvPrefixTextStatement = (
   statementRange: SourceRange,
   tokenRange: TokenRange,
 ): ProtocolStatement | undefined => {
-  const trimmed = statementText.trim().replace(/;\s*$/u, "");
+  const trimmed = stripTrailingComment(statementText)
+    .trim()
+    .replace(/;\s*$/u, "");
   const prefixMatch = trimmed.match(/^prefix\s+(\S+)(?:\s+(\{[\s\S]*\}))?$/iu);
   if (!prefixMatch?.[1]) {
     return undefined;

--- a/packages/@birdcc/parser/src/declarations/protocol-radv.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol-radv.ts
@@ -6,6 +6,31 @@ type TokenRange = (token: string) => SourceRange;
 const stripQuotedText = (value: string): string =>
   value.replace(/^(['"])(.*)\1$/u, "$2");
 
+const stripTrailingComment = (value: string): string => {
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if (char === '"' && !inSingleQuote) {
+      inDoubleQuote = !inDoubleQuote;
+      continue;
+    }
+
+    if (char === "'" && !inDoubleQuote) {
+      inSingleQuote = !inSingleQuote;
+      continue;
+    }
+
+    if (!inSingleQuote && !inDoubleQuote) {
+      if (char === "#" || (char === "/" && value[index + 1] === "/")) {
+        return value.slice(0, index);
+      }
+    }
+  }
+
+  return value;
+};
+
 const parseBoolToken = (value: string | undefined): boolean | undefined => {
   if (!value) {
     return undefined;
@@ -412,7 +437,7 @@ export const parseRadvInterfaceTextStatement = (
 ): ProtocolStatement | undefined => {
   const trimmed = statementText.trim().replace(/;\s*$/u, "");
   const interfaceMatch = trimmed.match(/^interface\b(.*)$/isu);
-  const rest = interfaceMatch?.[1]?.trim();
+  const rest = stripTrailingComment((interfaceMatch?.[1] ?? "").trim()).trim();
   if (!rest) {
     return undefined;
   }

--- a/packages/@birdcc/parser/src/declarations/protocol-radv.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol-radv.ts
@@ -424,7 +424,7 @@ export const parseRadvInterfaceTextStatement = (
   }
 
   const cleanedRest = rest
-    .replace(/\s*;?\s*(?:#.*|\/\/.*|\/[\s\S]*?\*\/)?\s*$/u, "")
+    .replace(/\s*;?\s*(?:#.*|\/\/.*|\/\*[\s\S]*?\*\/)?\s*$/u, "")
     .trim();
   const bodyMatch = cleanedRest.match(/\{[\s\S]*\}$/u);
   const bodyText = bodyMatch?.[0];
@@ -497,7 +497,7 @@ export const parseRadvPrefixTextStatement = (
 ): ProtocolStatement | undefined => {
   const trimmed = statementText.trim();
   const prefixMatch = trimmed.match(
-    /^prefix\s+(\S+)(?:\s+(\{[\s\S]*\}))?\s*(?:;?\s*(?:#.*|\/\/.*|\/[\s\S]*?\*\/)?\s*)?$/iu,
+    /^prefix\s+(\S+)(?:\s+(\{[\s\S]*\}))?\s*(?:;?\s*(?:#.*|\/\/.*|\/\*[\s\S]*?\*\/)?\s*)?$/iu,
   );
   if (!prefixMatch?.[1]) {
     return undefined;
@@ -527,7 +527,7 @@ export const parseRadvDnsTextStatement = (
 ): ProtocolStatement | undefined => {
   const trimmed = statementText.trim();
   const dnsBlockMatch = trimmed.match(
-    /^(rdnss|dnssl)\s+(\{[\s\S]*\})\s*(?:;?\s*(?:#.*|\/\/.*|\/[\s\S]*?\*\/)?\s*)?$/iu,
+    /^(rdnss|dnssl)\s+(\{[\s\S]*\})\s*(?:;?\s*(?:#.*|\/\/.*|\/\*[\s\S]*?\*\/)?\s*)?$/iu,
   );
   if (dnsBlockMatch?.[1] && dnsBlockMatch[2]) {
     const block = dnsBlockMatch[1].toLowerCase() as "rdnss" | "dnssl";

--- a/packages/@birdcc/parser/src/declarations/protocol-radv.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol-radv.ts
@@ -36,7 +36,7 @@ const parseRadvCustomOptionParts = (
   const customOptionMatch = statementText.match(
     /^custom\s+option\s+type\s+(.+?)\s+value\s+(.+)$/iu,
   );
-  if (!customOptionMatch?.[1] || !customOptionMatch[2]) {
+  if (!customOptionMatch || !customOptionMatch[1] || !customOptionMatch[2]) {
     return undefined;
   }
 
@@ -149,6 +149,7 @@ const parseRadvPrefixEntries = (
     .map((item) => item.trim())
     .filter(Boolean)
     .map((item) => {
+      const itemRange = tokenRange(item);
       const boolMatch = item.match(
         /^(skip|onlink|autonomous|pd\s+preferred)(?:\s+(\S+))?$/iu,
       );
@@ -160,7 +161,7 @@ const parseRadvPrefixEntries = (
           value: parseBoolToken(valueText) ?? true,
           valueText,
           valueRange: valueText ? tokenRange(valueText) : undefined,
-          ...bodyRange,
+          ...itemRange,
         };
       }
 
@@ -181,14 +182,14 @@ const parseRadvPrefixEntries = (
           sensitive: parseBoolToken(sensitiveText),
           sensitiveText,
           sensitiveRange: sensitiveText ? tokenRange(sensitiveText) : undefined,
-          ...bodyRange,
+          ...itemRange,
         };
       }
 
       return {
         kind: "other",
         text: item,
-        ...bodyRange,
+        ...itemRange,
       };
     });
 };
@@ -207,6 +208,7 @@ const parseRadvInterfaceEntries = (
     .map((item) => item.trim())
     .filter(Boolean)
     .map((item) => {
+      const itemRange = tokenRange(item);
       const prefixMatch = item.match(/^prefix\s+(\S+)(?:\s+(\{[\s\S]*\}))?$/iu);
       if (prefixMatch?.[1]) {
         const prefix = prefixMatch[1];
@@ -218,12 +220,17 @@ const parseRadvInterfaceEntries = (
           kind: "prefix",
           prefix,
           prefixRange: tokenRange(prefix),
-          entries: prefixBodyText
-            ? parseRadvPrefixEntries(prefixBodyText, bodyRange, tokenRange)
-            : [],
+          entries:
+            prefixBodyText && prefixBodyRange
+              ? parseRadvPrefixEntries(
+                  prefixBodyText,
+                  prefixBodyRange,
+                  tokenRange,
+                )
+              : [],
           bodyText: prefixBodyText,
           bodyRange: prefixBodyRange,
-          ...bodyRange,
+          ...itemRange,
         };
       }
 
@@ -240,7 +247,7 @@ const parseRadvInterfaceEntries = (
             | "min-delay",
           value,
           valueRange: tokenRange(value),
-          ...bodyRange,
+          ...itemRange,
         };
       }
 
@@ -259,7 +266,7 @@ const parseRadvInterfaceEntries = (
           value: parseBoolToken(valueText) ?? true,
           valueText,
           valueRange: valueText ? tokenRange(valueText) : undefined,
-          ...bodyRange,
+          ...itemRange,
         };
       }
 
@@ -277,7 +284,7 @@ const parseRadvInterfaceEntries = (
             | "current-hop-limit",
           value,
           valueRange: tokenRange(value),
-          ...bodyRange,
+          ...itemRange,
         };
       }
 
@@ -297,7 +304,7 @@ const parseRadvInterfaceEntries = (
           sensitive: parseBoolToken(sensitiveText),
           sensitiveText,
           sensitiveRange: sensitiveText ? tokenRange(sensitiveText) : undefined,
-          ...bodyRange,
+          ...itemRange,
         };
       }
 
@@ -313,7 +320,7 @@ const parseRadvInterfaceEntries = (
             | "route-linger-time",
           value,
           valueRange: tokenRange(value),
-          ...bodyRange,
+          ...itemRange,
         };
       }
 
@@ -332,7 +339,7 @@ const parseRadvInterfaceEntries = (
             | "route-preference",
           value,
           valueRange: tokenRange(preferenceMatch[2]),
-          ...bodyRange,
+          ...itemRange,
         };
       }
 
@@ -351,7 +358,7 @@ const parseRadvInterfaceEntries = (
           value: parseBoolToken(valueText) ?? true,
           valueText,
           valueRange: valueText ? tokenRange(valueText) : undefined,
-          ...bodyRange,
+          ...itemRange,
         };
       }
 
@@ -364,7 +371,7 @@ const parseRadvInterfaceEntries = (
           entries: parseRadvDnsBlockEntries(kind, dnsBodyText, tokenRange),
           bodyText: dnsBodyText,
           bodyRange: tokenRange(dnsBodyText),
-          ...bodyRange,
+          ...itemRange,
         };
       }
 
@@ -377,7 +384,7 @@ const parseRadvInterfaceEntries = (
         return {
           kind,
           entries: [parseRadvDnsShorthandEntry(kind, valueText, tokenRange)],
-          ...bodyRange,
+          ...itemRange,
         };
       }
 
@@ -386,14 +393,14 @@ const parseRadvInterfaceEntries = (
         return {
           kind: "custom-option",
           ...customOption,
-          ...bodyRange,
+          ...itemRange,
         };
       }
 
       return {
         kind: "other",
         text: item,
-        ...bodyRange,
+        ...itemRange,
       };
     });
 };
@@ -416,7 +423,7 @@ export const parseRadvInterfaceTextStatement = (
     ? rest.slice(0, rest.indexOf(bodyText)).trim()
     : rest;
   const patternMatches = [
-    ...patternText.matchAll(/"[^"]+"|'[^']+'|,|\S+/gu),
+    ...patternText.matchAll(/"[^"]+"|'[^']+'|,|[^,\s]+/gu),
   ].filter((match) => match[0] !== ",");
   const patterns = patternMatches.map((match) => stripQuotedText(match[0]));
   const patternRanges = patternMatches.map((match) => tokenRange(match[0]));
@@ -487,9 +494,10 @@ export const parseRadvPrefixTextStatement = (
     kind: "radv-prefix",
     prefix,
     prefixRange: tokenRange(prefix),
-    entries: bodyText
-      ? parseRadvPrefixEntries(bodyText, statementRange, tokenRange)
-      : [],
+    entries:
+      bodyText && bodyRange
+        ? parseRadvPrefixEntries(bodyText, bodyRange, tokenRange)
+        : [],
     bodyText,
     bodyRange,
     ...statementRange,

--- a/packages/@birdcc/parser/src/declarations/protocol-radv.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol-radv.ts
@@ -142,7 +142,7 @@ const parseRadvDnsShorthandEntry = (
   if (blockKind === "rdnss") {
     return {
       kind: "ns",
-      value: valueText,
+      value: stripQuotedText(valueText),
       valueText,
       valueRange: tokenRange(valueText),
       ...tokenRange(valueText),

--- a/packages/@birdcc/parser/src/declarations/protocol-radv.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol-radv.ts
@@ -1,10 +1,7 @@
 import type { ProtocolStatement, SourceRange } from "../types.js";
-import { splitTopLevelStatements } from "./shared.js";
+import { splitTopLevelStatements, stripQuotedText } from "./shared.js";
 
 type TokenRange = (token: string) => SourceRange;
-
-const stripQuotedText = (value: string): string =>
-  value.replace(/^(['"])(.*)\1$/u, "$2");
 
 const stripTrailingComment = (value: string): string =>
   value

--- a/packages/@birdcc/parser/src/declarations/protocol.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol.ts
@@ -31,6 +31,7 @@ import {
   normalizeChannelType,
   protocolTypeTextAndRange,
   protocolStatementNodesOf,
+  splitTopLevelStatements,
 } from "./shared.js";
 import {
   parseRadvCustomOptionTextStatement,
@@ -4215,37 +4216,6 @@ const parseBabelInterfaceTextStatement = (
     bodyRange,
     ...statementRange,
   };
-};
-
-const splitTopLevelStatements = (body: string): string[] => {
-  const statements: string[] = [];
-  let depth = 0;
-  let start = 0;
-
-  for (let index = 0; index < body.length; index += 1) {
-    const char = body[index];
-    if (char === "{") {
-      depth += 1;
-      continue;
-    }
-
-    if (char === "}") {
-      depth = Math.max(0, depth - 1);
-      continue;
-    }
-
-    if (char === ";" && depth === 0) {
-      statements.push(body.slice(start, index));
-      start = index + 1;
-    }
-  }
-
-  const tail = body.slice(start).trim();
-  if (tail.length > 0) {
-    statements.push(tail);
-  }
-
-  return statements;
 };
 
 const parseRipOptionTextStatement = (

--- a/packages/@birdcc/parser/src/declarations/protocol.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol.ts
@@ -4482,14 +4482,14 @@ const parseProtocolInterfaceEntries = (
           address,
           addressKind: isIpLiteralCandidate(address) ? "ip" : "other",
           addressRange: tokenRange(address),
-          ...bodyRange,
+          ...tokenRange(item),
         };
       }
 
       return {
         kind: "other",
         text: item,
-        ...bodyRange,
+        ...tokenRange(item),
       };
     });
 };

--- a/packages/@birdcc/parser/src/declarations/protocol.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol.ts
@@ -4705,16 +4705,20 @@ const parseStaticRouteOptions = (
     }
 
     if (optionText === "onlink" || optionText === "bfd") {
+      const boolValue = parseBoolToken(valueText);
       options.push({
         kind: optionText,
-        value: parseBoolToken(valueText) ?? true,
-        valueText,
-        valueRange: isNode(valueNode) ? toRange(valueNode, source) : undefined,
-        ...(isNode(valueNode)
+        value: boolValue ?? true,
+        valueText: boolValue !== undefined ? valueText : undefined,
+        valueRange:
+          boolValue !== undefined && isNode(valueNode)
+            ? toRange(valueNode, source)
+            : undefined,
+        ...(boolValue !== undefined && isNode(valueNode)
           ? mergeRanges(toRange(optionNode, source), toRange(valueNode, source))
           : toRange(optionNode, source)),
       });
-      if (isNode(valueNode) && parseBoolToken(valueText) !== undefined) {
+      if (boolValue !== undefined) {
         index += 1;
       }
     }

--- a/packages/@birdcc/parser/src/declarations/protocol.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol.ts
@@ -2011,13 +2011,17 @@ const parseKernelOptionStatement = (
   }
 
   if (first === "merge" && second === "paths" && phraseNodes.length <= 5) {
-    const valueNode = phraseNodes[2];
+    const hasExplicitBool = phraseTextAt(phraseNodes, 2, source) !== "limit";
+    const valueNode = hasExplicitBool ? phraseNodes[2] : undefined;
     const valueText = isNode(valueNode) ? textOf(valueNode, source) : undefined;
-    const value = parseBoolToken(valueText);
+    const value = valueText !== undefined ? parseBoolToken(valueText) : true;
     if (value !== undefined) {
-      const limitNode =
-        phraseTextAt(phraseNodes, 3, source) === "limit"
+      const limitNode = hasExplicitBool
+        ? phraseTextAt(phraseNodes, 3, source) === "limit"
           ? phraseNodes[4]
+          : undefined
+        : phraseTextAt(phraseNodes, 2, source) === "limit"
+          ? phraseNodes[3]
           : undefined;
       const limit = isNode(limitNode) ? textOf(limitNode, source) : undefined;
       return {
@@ -4978,6 +4982,31 @@ const parseRpkiTransportEntries = (
     parseRpkiTransportEntry(statementText, tokenRange),
   );
 
+const RPKI_TEXT_ENTRY_PATTERNS = [
+  {
+    kind: "bird-private-key" as const,
+    pattern: new RegExp(
+      `^bird\\s+private\\s+key\\s+(${quotedOrBareToken})$`,
+      "iu",
+    ),
+  },
+  {
+    kind: "remote-public-key" as const,
+    pattern: new RegExp(
+      `^remote\\s+public\\s+key\\s+(${quotedOrBareToken})$`,
+      "iu",
+    ),
+  },
+  {
+    kind: "password" as const,
+    pattern: new RegExp(`^password\\s+(${quotedOrBareToken})$`, "iu"),
+  },
+  {
+    kind: "user" as const,
+    pattern: new RegExp(`^user\\s+(${quotedOrBareToken})$`, "iu"),
+  },
+];
+
 const parseRpkiTransportEntry = (
   statementText: string,
   tokenRange: (token: string) => SourceRange,
@@ -4996,32 +5025,7 @@ const parseRpkiTransportEntry = (
     };
   }
 
-  const textEntryPatterns = [
-    {
-      kind: "bird-private-key",
-      pattern: new RegExp(
-        `^bird\\s+private\\s+key\\s+(${quotedOrBareToken})$`,
-        "iu",
-      ),
-    },
-    {
-      kind: "remote-public-key",
-      pattern: new RegExp(
-        `^remote\\s+public\\s+key\\s+(${quotedOrBareToken})$`,
-        "iu",
-      ),
-    },
-    {
-      kind: "password",
-      pattern: new RegExp(`^password\\s+(${quotedOrBareToken})$`, "iu"),
-    },
-    {
-      kind: "user",
-      pattern: new RegExp(`^user\\s+(${quotedOrBareToken})$`, "iu"),
-    },
-  ] as const;
-
-  for (const entryPattern of textEntryPatterns) {
+  for (const entryPattern of RPKI_TEXT_ENTRY_PATTERNS) {
     const match = trimmed.match(entryPattern.pattern);
     if (!match?.[1]) {
       continue;

--- a/packages/@birdcc/parser/src/declarations/protocol.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol.ts
@@ -32,6 +32,7 @@ import {
   protocolTypeTextAndRange,
   protocolStatementNodesOf,
   splitTopLevelStatements,
+  stripQuotedText,
 } from "./shared.js";
 import {
   parseRadvCustomOptionTextStatement,
@@ -992,12 +993,6 @@ const STATIC_ROUTE_DESTINATIONS = new Set([
 
 const isNode = (node: SyntaxNode | undefined): node is SyntaxNode =>
   node !== undefined;
-
-const stripQuotedText = (value: string): string =>
-  (value.startsWith('"') && value.endsWith('"')) ||
-  (value.startsWith("'") && value.endsWith("'"))
-    ? value.slice(1, -1)
-    : value;
 
 const parseBoolToken = (value: string | undefined): boolean | undefined => {
   if (value === undefined) {
@@ -4442,7 +4437,7 @@ const parseRipInterfaceTextStatement = (
 ): ProtocolStatement | undefined => {
   const trimmed = statementText.trim().replace(/;\s*$/u, "");
   const interfaceMatch = trimmed.match(
-    /^interface\b([\s\S]*?)\s+(\{[\s\S]*\})$/iu,
+    /^interface\b([\s\S]*?)(\{[\s\S]*\})$/iu,
   );
   if (!interfaceMatch?.[1] || !interfaceMatch[2]) {
     return undefined;
@@ -4505,7 +4500,7 @@ const parseProtocolInterfaceTextStatement = (
 ): ProtocolStatement | undefined => {
   const trimmed = statementText.trim().replace(/;\s*$/u, "");
   const interfaceMatch = trimmed.match(
-    /^interface\b([\s\S]*?)\s+(\{[\s\S]*\})$/iu,
+    /^interface\b([\s\S]*?)(\{[\s\S]*\})$/iu,
   );
   if (!interfaceMatch?.[1] || !interfaceMatch[2]) {
     return undefined;
@@ -4800,6 +4795,11 @@ const unquoteProtocolToken = (value: string): string =>
 
 const quotedOrBareToken = "\"[^\"]+\"|'[^']+'|\\S+";
 
+const RPKI_REMOTE_PATTERN = new RegExp(
+  `^remote\\s+(${quotedOrBareToken})(?:\\s+port\\s+(\\S+))?$`,
+  "iu",
+);
+
 const rangeForStatementToken = (
   source: string,
   statementNode: SyntaxNode,
@@ -4852,12 +4852,7 @@ const parseRpkiOtherTextStatement = (
 ): ProtocolStatement | undefined => {
   const trimmed = statementText.trim().replace(/;\s*$/u, "");
 
-  const remoteMatch = trimmed.match(
-    new RegExp(
-      `^remote\\s+(${quotedOrBareToken})(?:\\s+port\\s+(\\S+))?$`,
-      "iu",
-    ),
-  );
+  const remoteMatch = trimmed.match(RPKI_REMOTE_PATTERN);
   if (remoteMatch) {
     const addressText = remoteMatch[1] ?? "";
     const address = unquoteProtocolToken(addressText);

--- a/packages/@birdcc/parser/src/declarations/shared.ts
+++ b/packages/@birdcc/parser/src/declarations/shared.ts
@@ -130,6 +130,7 @@ export const splitTopLevelStatements = (body: string): string[] => {
         ) {
           start += 1;
         }
+        index = start - 1;
       }
       continue;
     }

--- a/packages/@birdcc/parser/src/declarations/shared.ts
+++ b/packages/@birdcc/parser/src/declarations/shared.ts
@@ -118,6 +118,16 @@ export const splitTopLevelStatements = (body: string): string[] => {
 
     if (char === "}") {
       depth = Math.max(0, depth - 1);
+      if (depth === 0) {
+        statements.push(body.slice(start, index + 1));
+        start = index + 1;
+        while (
+          start < body.length &&
+          (body[start] === ";" || /\s/u.test(body[start] ?? ""))
+        ) {
+          start += 1;
+        }
+      }
       continue;
     }
 

--- a/packages/@birdcc/parser/src/declarations/shared.ts
+++ b/packages/@birdcc/parser/src/declarations/shared.ts
@@ -66,6 +66,37 @@ export const PROTOCOL_STATEMENT_TYPES = new Set([
   "expression_statement",
 ]);
 
+export const splitTopLevelStatements = (body: string): string[] => {
+  const statements: string[] = [];
+  let depth = 0;
+  let start = 0;
+
+  for (let index = 0; index < body.length; index += 1) {
+    const char = body[index];
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+
+    if (char === "}") {
+      depth = Math.max(0, depth - 1);
+      continue;
+    }
+
+    if (char === ";" && depth === 0) {
+      statements.push(body.slice(start, index));
+      start = index + 1;
+    }
+  }
+
+  const tail = body.slice(start).trim();
+  if (tail.length > 0) {
+    statements.push(tail);
+  }
+
+  return statements;
+};
+
 export const TABLE_TYPES = new Set([
   "routing",
   "ipv4",

--- a/packages/@birdcc/parser/src/declarations/shared.ts
+++ b/packages/@birdcc/parser/src/declarations/shared.ts
@@ -56,6 +56,12 @@ export type MatchExpression = FilterDeclaration["matches"][number];
 
 type ChannelStatement = Extract<ProtocolStatement, { kind: "channel" }>;
 
+export const stripQuotedText = (value: string): string =>
+  (value.startsWith('"') && value.endsWith('"')) ||
+  (value.startsWith("'") && value.endsWith("'"))
+    ? value.slice(1, -1)
+    : value;
+
 export const PROTOCOL_STATEMENT_TYPES = new Set([
   "local_role_statement",
   "local_as_statement",

--- a/packages/@birdcc/parser/src/declarations/shared.ts
+++ b/packages/@birdcc/parser/src/declarations/shared.ts
@@ -149,7 +149,10 @@ export const splitTopLevelStatements = (body: string): string[] => {
     }
 
     if (char === ";" && depth === 0) {
-      statements.push(body.slice(start, index));
+      const statement = body.slice(start, index).trim();
+      if (statement.length > 0) {
+        statements.push(statement);
+      }
       start = index + 1;
     }
   }

--- a/packages/@birdcc/parser/src/declarations/shared.ts
+++ b/packages/@birdcc/parser/src/declarations/shared.ts
@@ -77,10 +77,15 @@ export const splitTopLevelStatements = (body: string): string[] => {
 
     // Single-line comments (# or //)
     if (char === "#" || (char === "/" && nextChar === "/")) {
+      const commentStart = index;
       while (index < body.length && body[index] !== "\n") {
         index += 1;
       }
       if (depth === 0) {
+        const preComment = body.slice(start, commentStart).trim();
+        if (preComment.length > 0) {
+          statements.push(preComment);
+        }
         start = index < body.length ? index + 1 : body.length;
       }
       continue;
@@ -88,6 +93,7 @@ export const splitTopLevelStatements = (body: string): string[] => {
 
     // Multi-line comments (/* ... */)
     if (char === "/" && nextChar === "*") {
+      const commentStart = index;
       index += 2;
       while (index < body.length - 1) {
         if (body[index] === "*" && body[index + 1] === "/") {
@@ -95,6 +101,13 @@ export const splitTopLevelStatements = (body: string): string[] => {
           break;
         }
         index += 1;
+      }
+      if (depth === 0) {
+        const preComment = body.slice(start, commentStart).trim();
+        if (preComment.length > 0) {
+          statements.push(preComment);
+        }
+        start = index + 1;
       }
       continue;
     }

--- a/packages/@birdcc/parser/src/declarations/shared.ts
+++ b/packages/@birdcc/parser/src/declarations/shared.ts
@@ -73,6 +73,44 @@ export const splitTopLevelStatements = (body: string): string[] => {
 
   for (let index = 0; index < body.length; index += 1) {
     const char = body[index];
+    const nextChar = body[index + 1];
+
+    // Single-line comments (# or //)
+    if (char === "#" || (char === "/" && nextChar === "/")) {
+      while (index < body.length && body[index] !== "\n") {
+        index += 1;
+      }
+      continue;
+    }
+
+    // Multi-line comments (/* ... */)
+    if (char === "/" && nextChar === "*") {
+      index += 2;
+      while (index < body.length - 1) {
+        if (body[index] === "*" && body[index + 1] === "/") {
+          index += 1;
+          break;
+        }
+        index += 1;
+      }
+      continue;
+    }
+
+    // Quoted strings
+    if (char === '"' || char === "'") {
+      const quote = char;
+      index += 1;
+      while (index < body.length) {
+        if (body[index] === "\\") {
+          index += 1;
+        } else if (body[index] === quote) {
+          break;
+        }
+        index += 1;
+      }
+      continue;
+    }
+
     if (char === "{") {
       depth += 1;
       continue;

--- a/packages/@birdcc/parser/src/declarations/shared.ts
+++ b/packages/@birdcc/parser/src/declarations/shared.ts
@@ -80,6 +80,9 @@ export const splitTopLevelStatements = (body: string): string[] => {
       while (index < body.length && body[index] !== "\n") {
         index += 1;
       }
+      if (depth === 0) {
+        start = index < body.length ? index + 1 : body.length;
+      }
       continue;
     }
 

--- a/packages/@birdcc/parser/src/declarations/shared.ts
+++ b/packages/@birdcc/parser/src/declarations/shared.ts
@@ -87,11 +87,7 @@ export const splitTopLevelStatements = (body: string): string[] => {
       while (index < body.length && body[index] !== "\n") {
         index += 1;
       }
-      if (depth === 0) {
-        const preComment = body.slice(start, commentStart).trim();
-        if (preComment.length > 0) {
-          statements.push(preComment);
-        }
+      if (depth === 0 && body.slice(start, commentStart).trim().length === 0) {
         start = index < body.length ? index + 1 : body.length;
       }
       continue;
@@ -108,11 +104,7 @@ export const splitTopLevelStatements = (body: string): string[] => {
         }
         index += 1;
       }
-      if (depth === 0) {
-        const preComment = body.slice(start, commentStart).trim();
-        if (preComment.length > 0) {
-          statements.push(preComment);
-        }
+      if (depth === 0 && body.slice(start, commentStart).trim().length === 0) {
         start = index + 1;
       }
       continue;

--- a/packages/@birdcc/parser/test/parser.test.ts
+++ b/packages/@birdcc/parser/test/parser.test.ts
@@ -3748,6 +3748,53 @@ describe("@birdcc/parser tree-sitter", () => {
     }
   });
 
+  it("strips trailing comments from RADV custom option statements", async () => {
+    const sample = `
+      protocol radv ra1 {
+        custom option type 42 value 0102; # protocol-level comment
+
+        interface "eth0" {
+          custom option type 99 value 0xCAFE; # interface-level comment
+        };
+      }
+    `;
+
+    const parsed = await parseBirdConfig(sample);
+    expect(parsed.issues).toHaveLength(0);
+
+    const protocol = parsed.program.declarations.find(
+      (item) => item.kind === "protocol",
+    );
+    expect(protocol).toBeDefined();
+    if (protocol?.kind === "protocol") {
+      expect(protocol.statements).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: "radv-custom-option",
+            optionType: "42",
+            value: "0102",
+          }),
+        ]),
+      );
+
+      const iface = protocol.statements.find(
+        (item) => item.kind === "radv-interface",
+      );
+      expect(iface?.kind).toBe("radv-interface");
+      if (iface?.kind === "radv-interface") {
+        expect(iface.entries).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              kind: "custom-option",
+              optionType: "99",
+              value: "0xCAFE",
+            }),
+          ]),
+        );
+      }
+    }
+  });
+
   it("preserves generic protocol statements as other entries", async () => {
     const sample = `
       protocol ospf core {

--- a/packages/@birdcc/parser/test/parser.test.ts
+++ b/packages/@birdcc/parser/test/parser.test.ts
@@ -2415,6 +2415,7 @@ describe("@birdcc/parser tree-sitter", () => {
         igp table master4;
         route 192.0.2.0/24 via 198.51.100.1 dev "eth0" onlink yes weight 2 bfd no mpls 16000;
         route 198.51.100.0/24 via 192.0.2.1 bfd yes weight 1 via 192.0.2.2 weight 2;
+        route 203.0.113.0/24 via 198.51.100.2 onlink weight 3;
       }
     `);
 
@@ -2459,6 +2460,17 @@ describe("@birdcc/parser tree-sitter", () => {
               target: "192.0.2.2",
               options: [{ kind: "weight", value: "2" }],
             },
+          ],
+        },
+        {
+          kind: "static-route",
+          routeTarget: "203.0.113.0/24",
+          destinationType: "via",
+          nextHop: "198.51.100.2",
+          optionsText: "onlink weight 3",
+          options: [
+            { kind: "onlink", value: true },
+            { kind: "weight", value: "3" },
           ],
         },
       ]);

--- a/packages/@birdcc/parser/test/parser.test.ts
+++ b/packages/@birdcc/parser/test/parser.test.ts
@@ -3306,6 +3306,33 @@ describe("@birdcc/parser tree-sitter", () => {
     }
   });
 
+  it("strips trailing comments from RADV interface declarations", async () => {
+    const sample = `
+      protocol radv ra1 {
+        interface "eth0"; # trailing comment
+      }
+    `;
+
+    const parsed = await parseBirdConfig(sample);
+    expect(parsed.issues).toHaveLength(0);
+
+    const protocol = parsed.program.declarations.find(
+      (item) => item.kind === "protocol",
+    );
+    expect(protocol?.kind).toBe("protocol");
+    if (protocol?.kind === "protocol") {
+      expect(protocol.statements).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: "radv-interface",
+            patterns: ["eth0"],
+            entries: [],
+          }),
+        ]),
+      );
+    }
+  });
+
   it("parses comma-separated RADV interface patterns", async () => {
     const sample = `
       protocol radv ra1 {

--- a/packages/@birdcc/parser/test/parser.test.ts
+++ b/packages/@birdcc/parser/test/parser.test.ts
@@ -3484,6 +3484,44 @@ describe("@birdcc/parser tree-sitter", () => {
     }
   });
 
+  it("parses RADV protocol prefix blocks with trailing comments", async () => {
+    const sample = `
+      protocol radv ra1 {
+        prefix 2001:db8:2::/64 { # prefix block
+          skip no;
+          valid lifetime 3600 sensitive yes;
+        }; # end prefix
+      }
+    `;
+
+    const parsed = await parseBirdConfig(sample);
+    expect(parsed.issues).toHaveLength(0);
+
+    const protocol = parsed.program.declarations.find(
+      (item) => item.kind === "protocol",
+    );
+    expect(protocol).toBeDefined();
+    if (protocol?.kind === "protocol") {
+      expect(protocol.statements).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: "radv-prefix",
+            prefix: "2001:db8:2::/64",
+            entries: expect.arrayContaining([
+              expect.objectContaining({ kind: "skip", value: false }),
+              expect.objectContaining({
+                kind: "lifetime",
+                option: "valid-lifetime",
+                value: "3600",
+                sensitive: true,
+              }),
+            ]),
+          }),
+        ]),
+      );
+    }
+  });
+
   it("parses RADV protocol DNS blocks", async () => {
     const sample = `
       protocol radv ra1 {


### PR DESCRIPTION
## Summary
This PR introduces support for kernel, direct, perf, and static routing protocols, completes RPKI transport parsing, and delivers the full RADV (Router Advertisement) protocol implementation including the major refactor that splits RADV into its own declaration module.

## Depends on
- #141

## Changes

### Kernel & Direct Routing (`@birdcc/parser`)
- `feat(parser)`: Parse kernel protocol options
- `feat(parser)`: Parse device interface preferences
- `feat(parser)`: Parse direct protocol options
- `feat(parser)`: Parse perf protocol options

### Static & RPKI (`@birdcc/parser`)
- `feat(parser)`: Parse static route options
- `feat(parser)`: Parse RPKI transport entries
- `feat(parser)`: Parse static route nexthops

### RADV Protocol — Core (`@birdcc/parser`)
- `feat(parser)`: Parse RADV DNS blocks
- `feat(parser)`: Parse RADV protocol options
- `feat(parser)`: Parse RADV protocol prefixes
- `feat(parser)`: Parse RADV protocol DNS blocks
- `refactor(parser)`: Split RADV protocol parsing (`protocol-radv.ts`)

### RADV Protocol — Interface Options (`@birdcc/parser`)
- `feat(parser)`: Parse RADV custom options
- `feat(parser)`: Parse RADV local flags
- `feat(parser)`: Parse RADV interface timers
- `feat(parser)`: Parse RADV interface booleans
- `feat(parser)`: Parse RADV interface scalars
- `feat(parser)`: Parse RADV interface lifetimes
- `feat(parser)`: Parse RADV interface preferences
- `feat(parser)`: Parse RADV router discovery
- `feat(parser)`: Parse RADV DNS shorthand
- `test(parser)`: Cover RADV interface DNS shorthand
- `feat(parser)`: Parse RADV empty interfaces
- `feat(parser)`: Parse RADV lifetime expressions
- `feat(parser)`: Parse RADV custom option expressions
- `feat(parser)`: Parse RADV DNS lifetime expressions
- `fix(parser)`: Split RADV interface patterns

## Affected Packages
- `@birdcc/parser`

## Notes
The `refactor(parser): Split RADV protocol parsing` commit extracts RADV-specific logic from `protocol.ts` into the new `protocol-radv.ts` module. All subsequent RADV interface commits build on top of this refactor.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bird-chinese-community/codesmith/BIRD-LSP/pr/142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783696984&installation_id=136501088&pr_number=142&repository=bird-chinese-community%2FBIRD-LSP&return_to=https%3A%2F%2Fgithub.com%2Fbird-chinese-community%2FBIRD-LSP%2Fpull%2F142&signature=bb5e46b03c4507553363ff1ebc53dfaa21d2ba95305332f45c906f6f7c1636cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->