### PR TITLE
feat(parser): Top-level declarations (timeformat/watchdog) and BGP graceful restart / long-lived stale time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ refer/config-examples-private/*
 !refer/config-examples-private/.gitkeep
 
 .example/
+
+# Git worktrees
+.worktrees/

--- a/packages/@birdcc/parser/src/declarations/parse-declarations.ts
+++ b/packages/@birdcc/parser/src/declarations/parse-declarations.ts
@@ -758,6 +758,7 @@ export const parseDeclarations = (
       );
       if (watchdogFromTopLevel) {
         declarations.push(watchdogFromTopLevel);
+        continue;
       }
     }
   }

--- a/packages/@birdcc/parser/src/declarations/protocol.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol.ts
@@ -5408,13 +5408,7 @@ const mergeBmpLocalAddressStatements = (
       continue;
     }
 
-    const nextIndex = statements.findIndex(
-      (candidate, candidateIndex) =>
-        candidateIndex !== index &&
-        candidate.kind === "other" &&
-        candidate.line === statement.line &&
-        candidate.column === statement.endColumn + 1,
-    );
+    const nextIndex = nearestFollowingOtherIndex(statements, index, statement);
     const next = statements[nextIndex];
     if (next?.kind !== "other") {
       continue;

--- a/packages/@birdcc/parser/src/declarations/protocol.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol.ts
@@ -5342,7 +5342,7 @@ const nearestFollowingOtherIndex = (
     if (
       candidate &&
       candidate.line === statement.line &&
-      candidate.column > statement.endColumn &&
+      candidate.column >= statement.endColumn &&
       candidate.column < nearestColumn
     ) {
       nearestIndex = candidateIndex;

--- a/packages/@birdcc/parser/src/declarations/protocol.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol.ts
@@ -5341,6 +5341,7 @@ const nearestFollowingOtherIndex = (
     const candidate = statements[candidateIndex];
     if (
       candidate &&
+      candidate.kind === "other" &&
       candidate.line === statement.line &&
       candidate.column >= statement.endColumn &&
       candidate.column < nearestColumn
@@ -5350,8 +5351,7 @@ const nearestFollowingOtherIndex = (
     }
   }
 
-  const nearest = nearestIndex >= 0 ? statements[nearestIndex] : undefined;
-  return nearest?.kind === "other" ? nearestIndex : -1;
+  return nearestIndex;
 };
 
 const mergeRpkiLocalAddressStatements = (

--- a/packages/@birdcc/parser/src/declarations/protocol.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol.ts
@@ -5340,17 +5340,23 @@ const nearestFollowingOtherIndex = (
 
     const candidate = statements[candidateIndex];
     if (
-      candidate &&
+      candidate?.kind === "other" &&
       candidate.line === statement.line &&
       candidate.column > statement.endColumn &&
-      candidate.column < nearestColumn
+      candidate.column < nearestColumn &&
+      !statements.some(
+        (intermediate) =>
+          intermediate.line === statement.line &&
+          intermediate.column > statement.endColumn &&
+          intermediate.column < candidate.column,
+      )
     ) {
       nearestIndex = candidateIndex;
       nearestColumn = candidate.column;
     }
   }
 
-  const nearest = statements[nearestIndex];
+  const nearest = nearestIndex >= 0 ? statements[nearestIndex] : undefined;
   return nearest?.kind === "other" ? nearestIndex : -1;
 };
 

--- a/packages/@birdcc/parser/src/declarations/protocol.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol.ts
@@ -5340,16 +5340,10 @@ const nearestFollowingOtherIndex = (
 
     const candidate = statements[candidateIndex];
     if (
-      candidate?.kind === "other" &&
+      candidate &&
       candidate.line === statement.line &&
       candidate.column > statement.endColumn &&
-      candidate.column < nearestColumn &&
-      !statements.some(
-        (intermediate) =>
-          intermediate.line === statement.line &&
-          intermediate.column > statement.endColumn &&
-          intermediate.column < candidate.column,
-      )
+      candidate.column < nearestColumn
     ) {
       nearestIndex = candidateIndex;
       nearestColumn = candidate.column;

--- a/packages/@birdcc/parser/src/declarations/protocol.ts
+++ b/packages/@birdcc/parser/src/declarations/protocol.ts
@@ -5340,7 +5340,7 @@ const nearestFollowingOtherIndex = (
 
     const candidate = statements[candidateIndex];
     if (
-      candidate?.kind === "other" &&
+      candidate &&
       candidate.line === statement.line &&
       candidate.column > statement.endColumn &&
       candidate.column < nearestColumn
@@ -5350,7 +5350,8 @@ const nearestFollowingOtherIndex = (
     }
   }
 
-  return nearestIndex;
+  const nearest = statements[nearestIndex];
+  return nearest?.kind === "other" ? nearestIndex : -1;
 };
 
 const mergeRpkiLocalAddressStatements = (

--- a/packages/@birdcc/parser/src/declarations/top-level.ts
+++ b/packages/@birdcc/parser/src/declarations/top-level.ts
@@ -418,17 +418,20 @@ export const parseWatchdogFromStatement = (
   const optionEndLine = optionToken?.range.endLine ?? declarationRange.line;
   const optionEndColumn =
     optionToken?.range.endColumn ?? declarationRange.column;
-  const valueTokenStart = isStrictWatchdog
-    ? Math.max(
-        0,
-        tokens.findIndex(
-          (token) =>
-            token.range.line > optionEndLine ||
-            (token.range.line === optionEndLine &&
-              token.range.column >= optionEndColumn),
-        ),
+  const strictValueTokenStart = isStrictWatchdog
+    ? tokens.findIndex(
+        (token) =>
+          token.range.line > optionEndLine ||
+          (token.range.line === optionEndLine &&
+            token.range.column >= optionEndColumn),
       )
-    : 2;
+    : -1;
+  const valueTokenStart =
+    strictValueTokenStart === -1
+      ? isStrictWatchdog
+        ? tokens.length
+        : 2
+      : strictValueTokenStart;
   const valueTokens = tokens.slice(valueTokenStart);
   const value = valueTokens
     .map((token) => token.text)

--- a/packages/@birdcc/parser/src/declarations/top-level.ts
+++ b/packages/@birdcc/parser/src/declarations/top-level.ts
@@ -278,6 +278,10 @@ export const parseTableFromStatement = (
 
 const TIMEFORMAT_SCOPES = new Set(["route", "protocol", "base", "log"]);
 
+const isTimeformatScope = (
+  value: string,
+): value is TimeformatDeclaration["scope"] => TIMEFORMAT_SCOPES.has(value);
+
 const tokenLikeFromNode = (
   node: SyntaxNode | null,
   source: string,
@@ -321,25 +325,19 @@ export const parseTimeformatFromStatement = (
 
   const scopeToken = isStrictTimeformat
     ? tokenLikeFromNode(statementNode.childForFieldName("scope"), source)
-    : (tokenLikeFromNode(statementNode.childForFieldName("scope"), source) ??
-      tokens[1]);
+    : tokens[1];
   const formatToken = isStrictTimeformat
     ? tokenLikeFromNode(statementNode.childForFieldName("format"), source)
-    : (tokenLikeFromNode(statementNode.childForFieldName("format"), source) ??
-      tokens[2]);
+    : tokens[2];
   const limitToken = isStrictTimeformat
     ? tokenLikeFromNode(statementNode.childForFieldName("limit"), source)
-    : (tokenLikeFromNode(statementNode.childForFieldName("limit"), source) ??
-      tokens[3]);
+    : tokens[3];
   const fallbackFormatToken = isStrictTimeformat
     ? tokenLikeFromNode(
         statementNode.childForFieldName("fallback_format"),
         source,
       )
-    : (tokenLikeFromNode(
-        statementNode.childForFieldName("fallback_format"),
-        source,
-      ) ?? tokens[4]);
+    : tokens[4];
 
   if (!scopeToken) {
     issues.push({
@@ -357,9 +355,16 @@ export const parseTimeformatFromStatement = (
     });
   }
 
-  const scope = TIMEFORMAT_SCOPES.has(scopeToken?.lowered ?? "")
-    ? (scopeToken?.lowered as TimeformatDeclaration["scope"])
-    : "unknown";
+  if (limitToken && !fallbackFormatToken) {
+    issues.push({
+      code: "parser/missing-symbol",
+      message: "Missing fallback format for timeformat declaration with limit",
+      ...declarationRange,
+    });
+  }
+
+  const scopeText = scopeToken?.lowered ?? "";
+  const scope = isTimeformatScope(scopeText) ? scopeText : "unknown";
   const formatText = formatToken?.text ?? "";
 
   return {
@@ -382,6 +387,10 @@ export const parseTimeformatFromStatement = (
 
 const WATCHDOG_OPTIONS = new Set(["warning", "timeout"]);
 
+const isWatchdogOption = (
+  value: string,
+): value is WatchdogDeclaration["option"] => WATCHDOG_OPTIONS.has(value);
+
 export const parseWatchdogFromStatement = (
   statementNode: SyntaxNode,
   source: string,
@@ -401,8 +410,7 @@ export const parseWatchdogFromStatement = (
 
   const optionToken = isStrictWatchdog
     ? tokenLikeFromNode(statementNode.childForFieldName("option"), source)
-    : (tokenLikeFromNode(statementNode.childForFieldName("option"), source) ??
-      tokens[1]);
+    : tokens[1];
   const valueTokenStart = isStrictWatchdog ? 0 : 2;
   const valueTokens = tokens.slice(valueTokenStart);
   const value = valueTokens
@@ -432,9 +440,8 @@ export const parseWatchdogFromStatement = (
     });
   }
 
-  const option = WATCHDOG_OPTIONS.has(optionToken?.lowered ?? "")
-    ? (optionToken?.lowered as WatchdogDeclaration["option"])
-    : "unknown";
+  const optionText = optionToken?.lowered ?? "";
+  const option = isWatchdogOption(optionText) ? optionText : "unknown";
 
   return {
     kind: "watchdog",

--- a/packages/@birdcc/parser/src/declarations/top-level.ts
+++ b/packages/@birdcc/parser/src/declarations/top-level.ts
@@ -317,20 +317,29 @@ export const parseTimeformatFromStatement = (
     return null;
   }
 
-  const scopeToken =
-    tokenLikeFromNode(statementNode.childForFieldName("scope"), source) ??
-    tokens[1];
-  const formatToken =
-    tokenLikeFromNode(statementNode.childForFieldName("format"), source) ??
-    tokens[2];
-  const limitToken =
-    tokenLikeFromNode(statementNode.childForFieldName("limit"), source) ??
-    tokens[3];
-  const fallbackFormatToken =
-    tokenLikeFromNode(
-      statementNode.childForFieldName("fallback_format"),
-      source,
-    ) ?? tokens[4];
+  const isStrictTimeformat = statementNode.type === "timeformat_statement";
+
+  const scopeToken = isStrictTimeformat
+    ? tokenLikeFromNode(statementNode.childForFieldName("scope"), source)
+    : (tokenLikeFromNode(statementNode.childForFieldName("scope"), source) ??
+      tokens[1]);
+  const formatToken = isStrictTimeformat
+    ? tokenLikeFromNode(statementNode.childForFieldName("format"), source)
+    : (tokenLikeFromNode(statementNode.childForFieldName("format"), source) ??
+      tokens[2]);
+  const limitToken = isStrictTimeformat
+    ? tokenLikeFromNode(statementNode.childForFieldName("limit"), source)
+    : (tokenLikeFromNode(statementNode.childForFieldName("limit"), source) ??
+      tokens[3]);
+  const fallbackFormatToken = isStrictTimeformat
+    ? tokenLikeFromNode(
+        statementNode.childForFieldName("fallback_format"),
+        source,
+      )
+    : (tokenLikeFromNode(
+        statementNode.childForFieldName("fallback_format"),
+        source,
+      ) ?? tokens[4]);
 
   if (!scopeToken) {
     issues.push({
@@ -388,10 +397,13 @@ export const parseWatchdogFromStatement = (
     return null;
   }
 
-  const optionToken =
-    tokenLikeFromNode(statementNode.childForFieldName("option"), source) ??
-    tokens[1];
-  const valueTokenStart = statementNode.type === "watchdog_statement" ? 0 : 2;
+  const isStrictWatchdog = statementNode.type === "watchdog_statement";
+
+  const optionToken = isStrictWatchdog
+    ? tokenLikeFromNode(statementNode.childForFieldName("option"), source)
+    : (tokenLikeFromNode(statementNode.childForFieldName("option"), source) ??
+      tokens[1]);
+  const valueTokenStart = isStrictWatchdog ? 0 : 2;
   const valueTokens = tokens.slice(valueTokenStart);
   const value = valueTokens
     .map((token) => token.text)

--- a/packages/@birdcc/parser/src/declarations/top-level.ts
+++ b/packages/@birdcc/parser/src/declarations/top-level.ts
@@ -411,6 +411,8 @@ export const parseWatchdogFromStatement = (
   const optionToken = isStrictWatchdog
     ? tokenLikeFromNode(statementNode.childForFieldName("option"), source)
     : tokens[1];
+  // In strict statements the keyword and option are anonymous, so named
+  // children (and therefore tokens) start with the value(s).
   const valueTokenStart = isStrictWatchdog ? 0 : 2;
   const valueTokens = tokens.slice(valueTokenStart);
   const value = valueTokens

--- a/packages/@birdcc/parser/src/declarations/top-level.ts
+++ b/packages/@birdcc/parser/src/declarations/top-level.ts
@@ -359,7 +359,7 @@ export const parseTimeformatFromStatement = (
     issues.push({
       code: "parser/missing-symbol",
       message: "Missing fallback format for timeformat declaration with limit",
-      ...declarationRange,
+      ...(limitToken?.range ?? declarationRange),
     });
   }
 

--- a/packages/@birdcc/parser/src/declarations/top-level.ts
+++ b/packages/@birdcc/parser/src/declarations/top-level.ts
@@ -411,9 +411,24 @@ export const parseWatchdogFromStatement = (
   const optionToken = isStrictWatchdog
     ? tokenLikeFromNode(statementNode.childForFieldName("option"), source)
     : tokens[1];
-  // In strict statements the keyword and option are anonymous, so named
-  // children (and therefore tokens) start with the value(s).
-  const valueTokenStart = isStrictWatchdog ? 0 : 2;
+  // In strict statements the keyword and option are anonymous. Locate the
+  // first token that begins at or after the option ends so the value always
+  // starts at the actual value token, regardless of whether the option is
+  // included in the token list.
+  const optionEndLine = optionToken?.range.endLine ?? declarationRange.line;
+  const optionEndColumn =
+    optionToken?.range.endColumn ?? declarationRange.column;
+  const valueTokenStart = isStrictWatchdog
+    ? Math.max(
+        0,
+        tokens.findIndex(
+          (token) =>
+            token.range.line > optionEndLine ||
+            (token.range.line === optionEndLine &&
+              token.range.column >= optionEndColumn),
+        ),
+      )
+    : 2;
   const valueTokens = tokens.slice(valueTokenStart);
   const value = valueTokens
     .map((token) => token.text)


### PR DESCRIPTION
## Summary
The final PR in this stack introduces top-level declaration support (`timeformat`, `watchdog`) and completes the BGP options suite with disable-after-error, graceful restart timers, and long-lived stale time configurations.

## Depends on
- #143

## Changes

### Top-Level Declarations (`@birdcc/parser`)
- `feat(parser)`: Parse timeformat declarations
- `feat(parser)`: Parse watchdog declarations

### BGP Error Handling (`@birdcc/parser`)
- `feat(parser)`: Parse BGP disable-after-error option

### BGP Graceful Restart Timers (`@birdcc/parser`)
- `feat(parser)`: Parse BGP graceful restart time option
- `feat(parser)`: Parse BGP min graceful restart time option
- `feat(parser)`: Parse BGP max graceful restart time option

### BGP Long-Lived Stale Time (`@birdcc/parser`)
- `feat(parser)`: Parse BGP long-lived stale time option
- `feat(parser)`: Parse BGP min long-lived stale time option
- `feat(parser)`: Parse BGP max long-lived stale time option

## Affected Packages
- `@birdcc/parser`

## Merge Strategy
Please merge this stack **in order** (PR1 → PR2 → PR3 → PR4 → PR5). Each PR is a stacked branch based on the previous one.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bird-chinese-community/codesmith/BIRD-LSP/pr/144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783698545&installation_id=136501088&pr_number=144&repository=bird-chinese-community%2FBIRD-LSP&return_to=https%3A%2F%2Fgithub.com%2Fbird-chinese-community%2FBIRD-LSP%2Fpull%2F144&signature=e0865aea35844ac47c078c8a1e510c085e9d63128aaa5ca4a08056d36aaed9f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->