### PR TITLE
fix: harden BIRD project entry detection

### DIFF
--- a/.changeset/calm-birds-detect.md
+++ b/.changeset/calm-birds-detect.md
@@ -1,0 +1,8 @@
+---
+"@birdcc/core": patch
+"@birdcc/cli": patch
+"@birdcc/lsp": patch
+---
+
+Harden automatic BIRD project entry detection with parsed language evidence,
+resolved include topology, safe auto-selection, and foreign `.conf` guards.

--- a/.github/workflows/cross-platform-compat.yml
+++ b/.github/workflows/cross-platform-compat.yml
@@ -42,15 +42,17 @@ jobs:
 
   bird-parse-docker:
     name: Bird Parse Docker (${{ matrix.platform_tag }})
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ matrix.runs_on }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: linux/amd64
             platform_tag: linux-amd64
+            runs_on: blacksmith-4vcpu-ubuntu-2404
           - platform: linux/arm64
             platform_tag: linux-arm64
+            runs_on: blacksmith-4vcpu-ubuntu-2404-arm
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -63,7 +65,6 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @birdcc/cli... build
       - run: node tools/ci/smoke-cli-lint-fmt.mjs
-      - uses: docker/setup-qemu-action@v3
       - name: Setup Blacksmith Builder
         uses: useblacksmith/setup-docker-builder@v1
       - name: Build BIRD2 image

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,19 @@ Minimal example:
 }
 ```
 
+### Automatic entry detection
+
+Without a project file, `birdcc init` and editor integrations only auto-select
+configuration files that contain Tree-sitter-parsed BIRD declarations. File
+names and directory depth rank eligible candidates but do not establish BIRD
+language identity by themselves. Canonical names such as `bird.conf`,
+`bird2.conf`, `bird3.conf`, and `bird6.conf` remain valid while empty or
+temporarily invalid, and an explicit `main` value always records user intent.
+
+Ambiguous and multi-entry layouts are reported for review instead of being
+silently written as `main`. Relative and glob includes are resolved from the
+including file, and only existing reachable files contribute to entry ranking.
+
 ## VS Code Extension Settings
 
 ### Large File Guard

--- a/packages/@birdcc/cli/src/commands/init.ts
+++ b/packages/@birdcc/cli/src/commands/init.ts
@@ -3,7 +3,7 @@
  */
 
 import { access, readFile, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import {
   selectAutoDetectedEntry,
   sniffProjectEntrypoints,
@@ -53,16 +53,23 @@ const existingConfigHasEntry = async (configPath: string): Promise<boolean> => {
  */
 const buildConfig = async (
   root: string,
-  selectedEntry: EntryCandidate,
+  selectedEntry: EntryCandidate | null,
+  workspaces: string[],
 ): Promise<Record<string, unknown>> => {
   const config: Record<string, unknown> = {
     $schema: SCHEMA_URL,
-    main: `./${selectedEntry.path}`,
   };
 
-  const indentResult = await detectIndentSizeFromFiles(root, [
-    selectedEntry.path,
-  ]);
+  if (workspaces.length > 0) {
+    config.workspaces = workspaces;
+  } else if (selectedEntry) {
+    config.main = `./${selectedEntry.path}`;
+  }
+
+  const indentCandidates = selectedEntry
+    ? [selectedEntry.path]
+    : workspaces.map((workspacePath) => `${workspacePath}bird.conf`);
+  const indentResult = await detectIndentSizeFromFiles(root, indentCandidates);
   if (indentResult.indentSize !== undefined) {
     config.formatter = {
       indentSize: indentResult.indentSize,
@@ -70,6 +77,31 @@ const buildConfig = async (
   }
 
   return config;
+};
+
+const collectDetectedWorkspaces = (result: DetectionResult): string[] => {
+  if (result.kind !== "monorepo-multi-entry") {
+    return [];
+  }
+
+  return [
+    ...new Set(
+      result.candidates
+        .filter(
+          (candidate) =>
+            candidate.qualified !== false &&
+            candidate.score > 0 &&
+            (candidate.includedByCount ?? 0) === 0 &&
+            candidate.role !== "library" &&
+            candidate.role !== "fragment" &&
+            candidate.role !== "external",
+        )
+        .map((candidate) => {
+          const directory = dirname(candidate.path).replaceAll("\\", "/");
+          return directory === "." ? "./" : `${directory}/`;
+        }),
+    ),
+  ].sort();
 };
 
 /**
@@ -96,8 +128,9 @@ const formatDryRunOutput = async (
   lines.push(`Conclusion: ${result.kind} (confidence: ${result.confidence}%)`);
 
   const selectedEntry = selectAutoDetectedEntry(result);
-  if (selectedEntry) {
-    const config = await buildConfig(root, selectedEntry);
+  const workspaces = collectDetectedWorkspaces(result);
+  if (selectedEntry || workspaces.length > 0) {
+    const config = await buildConfig(root, selectedEntry, workspaces);
     lines.push(`→ Will write: ${JSON.stringify(config)}`);
   }
 
@@ -148,13 +181,18 @@ export const runInit = async (
     exclude: options.ignore,
   });
   const selectedEntry = selectAutoDetectedEntry(result);
+  const workspaces = collectDetectedWorkspaces(result);
 
   // JSON output mode
   if (options.json) {
     console.log(JSON.stringify(result, null, 2));
 
-    if (!options.dryRun && options.write && selectedEntry) {
-      const config = await buildConfig(root, selectedEntry);
+    if (
+      !options.dryRun &&
+      options.write &&
+      (selectedEntry || workspaces.length > 0)
+    ) {
+      const config = await buildConfig(root, selectedEntry, workspaces);
       await writeFile(
         configPath,
         JSON.stringify(config, null, 2) + "\n",
@@ -181,7 +219,7 @@ export const runInit = async (
 
   // Write mode
   if (options.write || !process.stdout.isTTY) {
-    if (!selectedEntry) {
+    if (!selectedEntry && workspaces.length === 0) {
       console.error(
         "Could not safely select a BIRD entry point. Review the candidates or configure main explicitly.",
       );
@@ -189,7 +227,7 @@ export const runInit = async (
       return;
     }
 
-    const config = await buildConfig(root, selectedEntry);
+    const config = await buildConfig(root, selectedEntry, workspaces);
     const configContent = JSON.stringify(config, null, 2) + "\n";
 
     if (!options.force && (await fileExists(configPath))) {
@@ -202,8 +240,9 @@ export const runInit = async (
 
     await writeFile(configPath, configContent, "utf8");
     console.log(`Created ${options.configName}`);
+    const entrySummary = selectedEntry?.path ?? workspaces.join(", ");
     console.log(
-      `  Entry: ${selectedEntry.path} (${result.kind}, confidence: ${result.confidence}%)`,
+      `  Entry: ${entrySummary} (${result.kind}, confidence: ${result.confidence}%)`,
     );
     return;
   }
@@ -217,7 +256,7 @@ export const runInit = async (
     );
   }
 
-  if (selectedEntry) {
+  if (selectedEntry || workspaces.length > 0) {
     console.log(`\nRun with --write to create ${options.configName}`);
   }
 };

--- a/packages/@birdcc/cli/src/commands/init.ts
+++ b/packages/@birdcc/cli/src/commands/init.ts
@@ -4,7 +4,12 @@
 
 import { access, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { sniffProjectEntrypoints, type DetectionResult } from "@birdcc/core";
+import {
+  selectAutoDetectedEntry,
+  sniffProjectEntrypoints,
+  type DetectionResult,
+  type EntryCandidate,
+} from "@birdcc/core";
 import { detectIndentSizeFromFiles } from "./init-indent.js";
 
 const SCHEMA_URL =
@@ -46,64 +51,22 @@ const existingConfigHasEntry = async (configPath: string): Promise<boolean> => {
 /**
  * Generate config object from detection result.
  */
-const collectIndentProbePaths = (result: DetectionResult): string[] => {
-  if (result.kind === "monorepo-multi-entry") {
-    return result.candidates
-      .filter(
-        (candidate) =>
-          candidate.role === "entry" || candidate.role === "unknown",
-      )
-      .slice(0, 5)
-      .map((candidate) => candidate.path);
-  }
-
-  return result.primary ? [result.primary.path] : [];
-};
-
 const buildConfig = async (
   root: string,
-  result: DetectionResult,
+  selectedEntry: EntryCandidate,
 ): Promise<Record<string, unknown>> => {
   const config: Record<string, unknown> = {
     $schema: SCHEMA_URL,
+    main: `./${selectedEntry.path}`,
   };
 
-  if (result.kind === "monorepo-multi-entry" && result.candidates.length > 0) {
-    // Extract workspace directories from entry candidates
-    const entryDirs = new Set<string>();
-    for (const candidate of result.candidates) {
-      if (candidate.role === "entry" || candidate.role === "unknown") {
-        const dir = candidate.path.split("/").slice(0, -1).join("/");
-        if (dir) {
-          entryDirs.add(dir + "/");
-        } else {
-          // Root-level entry — include "." as a workspace dir
-          entryDirs.add(".");
-        }
-      }
-    }
-    if (entryDirs.size > 0) {
-      config.workspaces = [...entryDirs].sort();
-    }
-    // Also set main to the primary entry for clarity
-    if (result.primary) {
-      config.main = `./${result.primary.path}`;
-    }
-  } else if (result.primary) {
-    config.main = `./${result.primary.path}`;
-  }
-
-  const indentProbePaths = collectIndentProbePaths(result);
-  if (indentProbePaths.length > 0) {
-    const indentResult = await detectIndentSizeFromFiles(
-      root,
-      indentProbePaths,
-    );
-    if (indentResult.indentSize !== undefined) {
-      config.formatter = {
-        indentSize: indentResult.indentSize,
-      };
-    }
+  const indentResult = await detectIndentSizeFromFiles(root, [
+    selectedEntry.path,
+  ]);
+  if (indentResult.indentSize !== undefined) {
+    config.formatter = {
+      indentSize: indentResult.indentSize,
+    };
   }
 
   return config;
@@ -132,8 +95,9 @@ const formatDryRunOutput = async (
   lines.push("");
   lines.push(`Conclusion: ${result.kind} (confidence: ${result.confidence}%)`);
 
-  if (result.primary) {
-    const config = await buildConfig(root, result);
+  const selectedEntry = selectAutoDetectedEntry(result);
+  if (selectedEntry) {
+    const config = await buildConfig(root, selectedEntry);
     lines.push(`→ Will write: ${JSON.stringify(config)}`);
   }
 
@@ -183,13 +147,14 @@ export const runInit = async (
     maxFiles: options.maxFiles,
     exclude: options.ignore,
   });
+  const selectedEntry = selectAutoDetectedEntry(result);
 
   // JSON output mode
   if (options.json) {
     console.log(JSON.stringify(result, null, 2));
 
-    if (!options.dryRun && options.write && result.primary) {
-      const config = await buildConfig(root, result);
+    if (!options.dryRun && options.write && selectedEntry) {
+      const config = await buildConfig(root, selectedEntry);
       await writeFile(
         configPath,
         JSON.stringify(config, null, 2) + "\n",
@@ -216,13 +181,15 @@ export const runInit = async (
 
   // Write mode
   if (options.write || !process.stdout.isTTY) {
-    if (!result.primary && result.kind !== "monorepo-multi-entry") {
-      console.error("Could not determine a primary entry point.");
+    if (!selectedEntry) {
+      console.error(
+        "Could not safely select a BIRD entry point. Review the candidates or configure main explicitly.",
+      );
       process.exitCode = 1;
       return;
     }
 
-    const config = await buildConfig(root, result);
+    const config = await buildConfig(root, selectedEntry);
     const configContent = JSON.stringify(config, null, 2) + "\n";
 
     if (!options.force && (await fileExists(configPath))) {
@@ -236,7 +203,7 @@ export const runInit = async (
     await writeFile(configPath, configContent, "utf8");
     console.log(`Created ${options.configName}`);
     console.log(
-      `  Entry: ${result.primary?.path ?? "workspaces"} (${result.kind}, confidence: ${result.confidence}%)`,
+      `  Entry: ${selectedEntry.path} (${result.kind}, confidence: ${result.confidence}%)`,
     );
     return;
   }
@@ -250,7 +217,7 @@ export const runInit = async (
     );
   }
 
-  if (result.primary || result.kind === "monorepo-multi-entry") {
+  if (selectedEntry) {
     console.log(`\nRun with --write to create ${options.configName}`);
   }
 };

--- a/packages/@birdcc/cli/src/index.ts
+++ b/packages/@birdcc/cli/src/index.ts
@@ -4,6 +4,7 @@ import { dirname, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
   resolveCrossFileReferences,
+  selectAutoDetectedEntry,
   sniffProjectEntrypoints,
   type BirdDiagnostic,
   type BirdDiagnosticSeverity,
@@ -529,12 +530,13 @@ const resolveAutoProjectContext = async (
       maxDepth: 8,
       maxFiles: 2_000,
     });
-    if (!detection.primary) {
+    const selectedEntry = selectAutoDetectedEntry(detection);
+    if (!selectedEntry) {
       continue;
     }
 
-    const entryPath = resolve(rootPath, detection.primary.path);
-    const score = detection.primary.score;
+    const entryPath = resolve(rootPath, selectedEntry.path);
+    const score = selectedEntry.score;
     if (!best || score > best.score) {
       best = {
         rootPath,

--- a/packages/@birdcc/cli/test/init-integration.test.ts
+++ b/packages/@birdcc/cli/test/init-integration.test.ts
@@ -1,0 +1,73 @@
+import { access, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runInit, type InitOptions } from "../src/commands/init.js";
+
+const configExists = async (root: string): Promise<boolean> => {
+  try {
+    await access(join(root, "bird.config.json"));
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+describe("birdcc init detector integration", () => {
+  let root = "";
+  const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  const baseOptions: InitOptions = {
+    configName: "bird.config.json",
+    dryRun: false,
+    write: false,
+    force: false,
+    json: false,
+  };
+
+  beforeEach(async () => {
+    process.exitCode = undefined;
+    root = await mkdtemp(join(tmpdir(), "birdcc-init-foreign-"));
+    await writeFile(
+      join(root, "nginx.conf"),
+      "events {}\nhttp { server { listen 80; } }\n",
+      "utf8",
+    );
+  });
+
+  afterEach(async () => {
+    consoleLog.mockClear();
+    consoleError.mockClear();
+    process.exitCode = undefined;
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it.each([
+    ["ordinary", {}],
+    ["write", { write: true }],
+    ["json write", { json: true, write: true }],
+  ])(
+    "does not create a config for foreign-only projects in %s mode",
+    async (_name, overrides) => {
+      await runInit(root, { ...baseOptions, ...overrides });
+
+      expect(await configExists(root)).toBe(false);
+    },
+  );
+
+  it("shows rejected candidates in JSON mode", async () => {
+    await runInit(root, { ...baseOptions, json: true });
+
+    const result = JSON.parse(String(consoleLog.mock.calls[0]?.[0])) as {
+      kind: string;
+      primary: unknown;
+      candidates: Array<{ path: string; qualified?: boolean }>;
+    };
+    expect(result.kind).toBe("not-found");
+    expect(result.primary).toBeNull();
+    expect(result.candidates).toContainEqual(
+      expect.objectContaining({ path: "nginx.conf", qualified: false }),
+    );
+  });
+});

--- a/packages/@birdcc/cli/test/init-integration.test.ts
+++ b/packages/@birdcc/cli/test/init-integration.test.ts
@@ -1,4 +1,11 @@
-import { access, mkdtemp, rm, writeFile } from "node:fs/promises";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -69,5 +76,29 @@ describe("birdcc init detector integration", () => {
     expect(result.candidates).toContainEqual(
       expect.objectContaining({ path: "nginx.conf", qualified: false }),
     );
+  });
+
+  it("writes workspaces without a main for independent entries", async () => {
+    await rm(join(root, "nginx.conf"));
+    await mkdir(join(root, "tokyo"));
+    await mkdir(join(root, "osaka"));
+    await writeFile(
+      join(root, "tokyo", "bird.conf"),
+      "router id 192.0.2.1;\nprotocol device {}\n",
+      "utf8",
+    );
+    await writeFile(
+      join(root, "osaka", "bird.conf"),
+      "router id 192.0.2.2;\nprotocol device {}\n",
+      "utf8",
+    );
+
+    await runInit(root, { ...baseOptions, write: true });
+
+    const config = JSON.parse(
+      await readFile(join(root, "bird.config.json"), "utf8"),
+    ) as { main?: string; workspaces?: string[] };
+    expect(config.main).toBeUndefined();
+    expect(config.workspaces).toEqual(["osaka/", "tokyo/"]);
   });
 });

--- a/packages/@birdcc/cli/test/init.test.ts
+++ b/packages/@birdcc/cli/test/init.test.ts
@@ -11,6 +11,9 @@ import {
 
 vi.mock("@birdcc/core", () => ({
   sniffProjectEntrypoints: vi.fn(),
+  selectAutoDetectedEntry: vi.fn(
+    (result: { primary?: unknown }) => result.primary ?? null,
+  ),
 }));
 
 import { sniffProjectEntrypoints } from "@birdcc/core";

--- a/packages/@birdcc/core/src/detection/collector.ts
+++ b/packages/@birdcc/core/src/detection/collector.ts
@@ -32,7 +32,14 @@ const DEFAULT_IGNORE_DIRS = new Set([
 ]);
 
 /** Canonical entry file names (highest priority) */
-const CANONICAL_NAMES = new Set(["bird.conf", "bird6.conf"]);
+const CANONICAL_NAMES = new Set([
+  ".bird2.conf",
+  ".bird3.conf",
+  "bird.conf",
+  "bird2.conf",
+  "bird3.conf",
+  "bird6.conf",
+]);
 
 export interface CollectedFile {
   /** Relative path from root */
@@ -145,7 +152,7 @@ export const collectCandidateFiles = async (
 
       if (isFile && entry.name.endsWith(".conf")) {
         fileCount++;
-        const relativePath = relative(root, fullPath);
+        const relativePath = relative(root, fullPath).replaceAll("\\", "/");
         files.push({
           relativePath,
           depth,
@@ -161,25 +168,10 @@ export const collectCandidateFiles = async (
 };
 
 /**
- * Runs shallow-first collection: first checks depth 0-2 for canonical names,
- * falls back to full scan only if needed.
+ * Collect all bounded candidates. Ranking applies shallow/canonical priority
+ * after collection so a shallow entry cannot hide deeper monorepo instances.
  */
 export const collectWithShallowPriority = async (
   root: string,
   opts?: DetectionOptions,
-): Promise<CollectorResult> => {
-  // First pass: shallow scan (depth 0-2)
-  const shallowResult = await collectCandidateFiles(root, {
-    ...opts,
-    maxDepth: 2,
-  });
-
-  const canonicalShallow = shallowResult.files.filter((f) => f.isCanonical);
-  if (canonicalShallow.length > 0) {
-    return shallowResult;
-  }
-
-  // No canonical entry discovered in shallow scan.
-  // Fall back to full scan to avoid missing deeper entrypoints.
-  return collectCandidateFiles(root, opts);
-};
+): Promise<CollectorResult> => collectCandidateFiles(root, opts);

--- a/packages/@birdcc/core/src/detection/content-scanner.ts
+++ b/packages/@birdcc/core/src/detection/content-scanner.ts
@@ -133,10 +133,10 @@ const extractParsedContentSignals = (
         ),
       ),
     hasProtocolDevice: protocols.some(
-      (protocol) => protocol.protocolType.toLowerCase() === "device",
+      (protocol) => protocol.protocolType?.toLowerCase() === "device",
     ),
     hasProtocolKernel: protocols.some(
-      (protocol) => protocol.protocolType.toLowerCase() === "kernel",
+      (protocol) => protocol.protocolType?.toLowerCase() === "kernel",
     ),
     hasLogDirective: legacySignals.hasLogDirective,
     hasProtocolBlock: protocols.length > 0,
@@ -163,14 +163,18 @@ export const analyzeFileContent = async (
   const content = await readFileHead(join(root, relativePath));
   if (content === null) return null;
 
-  const parsed = await parseBirdConfig(content);
-  return {
-    signals: extractParsedContentSignals(content, parsed),
-    eligibility: evaluateParsedBirdDocumentEligibility(parsed, {
-      filePath: relativePath,
-      explicitMain,
-    }),
-  };
+  try {
+    const parsed = await parseBirdConfig(content);
+    return {
+      signals: extractParsedContentSignals(content, parsed),
+      eligibility: evaluateParsedBirdDocumentEligibility(parsed, {
+        filePath: relativePath,
+        explicitMain,
+      }),
+    };
+  } catch {
+    return null;
+  }
 };
 
 /**

--- a/packages/@birdcc/core/src/detection/content-scanner.ts
+++ b/packages/@birdcc/core/src/detection/content-scanner.ts
@@ -119,11 +119,10 @@ const extractParsedContentSignals = (
   parsed: ParsedBirdDocument,
 ): ContentSignals => {
   const legacySignals = extractContentSignals(content);
-  const declarations = parsed?.program?.declarations ?? [];
-  const protocols = declarations.filter(
+  const protocols = parsed.program.declarations.filter(
     (declaration) => declaration.kind === "protocol",
   );
-  const hasGlobalRouterId = declarations.some(
+  const hasGlobalRouterId = parsed.program.declarations.some(
     (declaration) => declaration.kind === "router-id",
   );
 
@@ -132,7 +131,7 @@ const extractParsedContentSignals = (
     hasProtocolRouterIdOnly:
       !hasGlobalRouterId &&
       protocols.some((protocol) =>
-        protocol.statements?.some(
+        protocol.statements.some(
           (statement) => statement.kind === "protocol-router-id",
         ),
       ),
@@ -144,10 +143,10 @@ const extractParsedContentSignals = (
     ),
     hasLogDirective: legacySignals.hasLogDirective,
     hasProtocolBlock: protocols.length > 0,
-    hasDefine: declarations.some(
+    hasDefine: parsed.program.declarations.some(
       (declaration) => declaration.kind === "define",
     ),
-    includeStatements: declarations.flatMap((declaration) =>
+    includeStatements: parsed.program.declarations.flatMap((declaration) =>
       declaration.kind === "include" && typeof declaration.path === "string"
         ? [declaration.path]
         : [],

--- a/packages/@birdcc/core/src/detection/content-scanner.ts
+++ b/packages/@birdcc/core/src/detection/content-scanner.ts
@@ -119,10 +119,11 @@ const extractParsedContentSignals = (
   parsed: ParsedBirdDocument,
 ): ContentSignals => {
   const legacySignals = extractContentSignals(content);
-  const protocols = parsed.program.declarations.filter(
+  const declarations = parsed?.program?.declarations ?? [];
+  const protocols = declarations.filter(
     (declaration) => declaration.kind === "protocol",
   );
-  const hasGlobalRouterId = parsed.program.declarations.some(
+  const hasGlobalRouterId = declarations.some(
     (declaration) => declaration.kind === "router-id",
   );
 
@@ -131,7 +132,7 @@ const extractParsedContentSignals = (
     hasProtocolRouterIdOnly:
       !hasGlobalRouterId &&
       protocols.some((protocol) =>
-        protocol.statements.some(
+        protocol.statements?.some(
           (statement) => statement.kind === "protocol-router-id",
         ),
       ),
@@ -143,10 +144,10 @@ const extractParsedContentSignals = (
     ),
     hasLogDirective: legacySignals.hasLogDirective,
     hasProtocolBlock: protocols.length > 0,
-    hasDefine: parsed.program.declarations.some(
+    hasDefine: declarations.some(
       (declaration) => declaration.kind === "define",
     ),
-    includeStatements: parsed.program.declarations.flatMap((declaration) =>
+    includeStatements: declarations.flatMap((declaration) =>
       declaration.kind === "include" && typeof declaration.path === "string"
         ? [declaration.path]
         : [],

--- a/packages/@birdcc/core/src/detection/content-scanner.ts
+++ b/packages/@birdcc/core/src/detection/content-scanner.ts
@@ -5,8 +5,10 @@
 
 import { open } from "node:fs/promises";
 import { join } from "node:path";
+import { parseBirdConfig, type ParsedBirdDocument } from "@birdcc/parser";
 import { scanBraceDepth } from "./brace-scanner.js";
-import type { ContentSignals } from "./types.js";
+import { evaluateParsedBirdDocumentEligibility } from "./eligibility.js";
+import type { BirdDocumentEligibility, ContentSignals } from "./types.js";
 
 /** Maximum bytes to read per file for content scanning */
 const MAX_SCAN_BYTES = 64 * 1024;
@@ -109,6 +111,68 @@ export const extractContentSignals = (content: string): ContentSignals => {
   };
 };
 
+const extractParsedContentSignals = (
+  content: string,
+  parsed: ParsedBirdDocument,
+): ContentSignals => {
+  const legacySignals = extractContentSignals(content);
+  const protocols = parsed.program.declarations.filter(
+    (declaration) => declaration.kind === "protocol",
+  );
+  const hasGlobalRouterId = parsed.program.declarations.some(
+    (declaration) => declaration.kind === "router-id",
+  );
+
+  return {
+    hasGlobalRouterId,
+    hasProtocolRouterIdOnly:
+      !hasGlobalRouterId &&
+      protocols.some((protocol) =>
+        protocol.statements.some(
+          (statement) => statement.kind === "protocol-router-id",
+        ),
+      ),
+    hasProtocolDevice: protocols.some(
+      (protocol) => protocol.protocolType.toLowerCase() === "device",
+    ),
+    hasProtocolKernel: protocols.some(
+      (protocol) => protocol.protocolType.toLowerCase() === "kernel",
+    ),
+    hasLogDirective: legacySignals.hasLogDirective,
+    hasProtocolBlock: protocols.length > 0,
+    hasDefine: parsed.program.declarations.some(
+      (declaration) => declaration.kind === "define",
+    ),
+    includeStatements: parsed.program.declarations
+      .filter((declaration) => declaration.kind === "include")
+      .map((declaration) => declaration.path),
+    commentedIncludes: legacySignals.commentedIncludes,
+  };
+};
+
+export interface ScannedFileAnalysis {
+  signals: ContentSignals;
+  eligibility: BirdDocumentEligibility;
+}
+
+export const analyzeFileContent = async (
+  root: string,
+  relativePath: string,
+  explicitMain: boolean = false,
+): Promise<ScannedFileAnalysis | null> => {
+  const content = await readFileHead(join(root, relativePath));
+  if (content === null) return null;
+
+  const parsed = await parseBirdConfig(content);
+  return {
+    signals: extractParsedContentSignals(content, parsed),
+    eligibility: evaluateParsedBirdDocumentEligibility(parsed, {
+      filePath: relativePath,
+      explicitMain,
+    }),
+  };
+};
+
 /**
  * Scan a file: read head + extract signals.
  */
@@ -116,7 +180,6 @@ export const scanFileContent = async (
   root: string,
   relativePath: string,
 ): Promise<ContentSignals | null> => {
-  const content = await readFileHead(join(root, relativePath));
-  if (content === null) return null;
-  return extractContentSignals(content);
+  const analysis = await analyzeFileContent(root, relativePath);
+  return analysis?.signals ?? null;
 };

--- a/packages/@birdcc/core/src/detection/content-scanner.ts
+++ b/packages/@birdcc/core/src/detection/content-scanner.ts
@@ -7,7 +7,10 @@ import { open } from "node:fs/promises";
 import { join } from "node:path";
 import { parseBirdConfig, type ParsedBirdDocument } from "@birdcc/parser";
 import { scanBraceDepth } from "./brace-scanner.js";
-import { evaluateParsedBirdDocumentEligibility } from "./eligibility.js";
+import {
+  evaluateParsedBirdDocumentEligibility,
+  isCanonicalBirdConfigPath,
+} from "./eligibility.js";
 import type { BirdDocumentEligibility, ContentSignals } from "./types.js";
 
 /** Maximum bytes to read per file for content scanning */
@@ -175,6 +178,19 @@ export const analyzeFileContent = async (
       }),
     };
   } catch {
+    // A parser crash (syntax error, WASM limits) must not silently drop files
+    // that are eligible by explicit main or canonical filename. Fall back to
+    // regex-based signals so LSP/formatting stay active through transient errors.
+    if (explicitMain || isCanonicalBirdConfigPath(relativePath)) {
+      return {
+        signals: extractContentSignals(content),
+        eligibility: {
+          eligible: true,
+          reason: explicitMain ? "explicit-main" : "canonical-filename",
+          declarationKinds: [],
+        },
+      };
+    }
     return null;
   }
 };

--- a/packages/@birdcc/core/src/detection/content-scanner.ts
+++ b/packages/@birdcc/core/src/detection/content-scanner.ts
@@ -143,9 +143,11 @@ const extractParsedContentSignals = (
     hasDefine: parsed.program.declarations.some(
       (declaration) => declaration.kind === "define",
     ),
-    includeStatements: parsed.program.declarations
-      .filter((declaration) => declaration.kind === "include")
-      .map((declaration) => declaration.path),
+    includeStatements: parsed.program.declarations.flatMap((declaration) =>
+      declaration.kind === "include" && typeof declaration.path === "string"
+        ? [declaration.path]
+        : [],
+    ),
     commentedIncludes: legacySignals.commentedIncludes,
   };
 };

--- a/packages/@birdcc/core/src/detection/eligibility.ts
+++ b/packages/@birdcc/core/src/detection/eligibility.ts
@@ -63,8 +63,9 @@ export const collectBirdDeclarationEvidence = (
   parsed: ParsedBirdDocument,
 ): BirdDeclarationEvidence[] => {
   const evidence = new Set<BirdDeclarationEvidence>();
+  const declarations = parsed?.program?.declarations ?? [];
 
-  for (const declaration of parsed.program.declarations) {
+  for (const declaration of declarations) {
     if (!isQualifyingDeclarationKind(declaration.kind)) {
       continue;
     }

--- a/packages/@birdcc/core/src/detection/eligibility.ts
+++ b/packages/@birdcc/core/src/detection/eligibility.ts
@@ -63,9 +63,8 @@ export const collectBirdDeclarationEvidence = (
   parsed: ParsedBirdDocument,
 ): BirdDeclarationEvidence[] => {
   const evidence = new Set<BirdDeclarationEvidence>();
-  const declarations = parsed?.program?.declarations ?? [];
 
-  for (const declaration of declarations) {
+  for (const declaration of parsed.program.declarations) {
     if (!isQualifyingDeclarationKind(declaration.kind)) {
       continue;
     }

--- a/packages/@birdcc/core/src/detection/eligibility.ts
+++ b/packages/@birdcc/core/src/detection/eligibility.ts
@@ -123,26 +123,26 @@ export const evaluateBirdDocumentEligibility = async (
   text: string,
   options?: BirdDocumentEligibilityOptions,
 ): Promise<BirdDocumentEligibility> => {
+  if (options?.explicitMain) {
+    return {
+      eligible: true,
+      reason: "explicit-main",
+      declarationKinds: [],
+    };
+  }
+
+  if (options?.filePath && isCanonicalBirdConfigPath(options.filePath)) {
+    return {
+      eligible: true,
+      reason: "canonical-filename",
+      declarationKinds: [],
+    };
+  }
+
   try {
     const parsed = await parseBirdConfig(text);
     return evaluateParsedBirdDocumentEligibility(parsed, options);
   } catch {
-    if (options?.explicitMain) {
-      return {
-        eligible: true,
-        reason: "explicit-main",
-        declarationKinds: [],
-      };
-    }
-
-    if (options?.filePath && isCanonicalBirdConfigPath(options.filePath)) {
-      return {
-        eligible: true,
-        reason: "canonical-filename",
-        declarationKinds: [],
-      };
-    }
-
     return {
       eligible: false,
       reason: "no-evidence",

--- a/packages/@birdcc/core/src/detection/eligibility.ts
+++ b/packages/@birdcc/core/src/detection/eligibility.ts
@@ -69,11 +69,11 @@ export const collectBirdDeclarationEvidence = (
       continue;
     }
 
-    if (
-      declaration.kind === "protocol" &&
-      !BIRD_PROTOCOL_TYPES.has(declaration.protocolType.toLowerCase())
-    ) {
-      continue;
+    if (declaration.kind === "protocol") {
+      const protocolType = declaration.protocolType?.toLowerCase();
+      if (!protocolType || !BIRD_PROTOCOL_TYPES.has(protocolType)) {
+        continue;
+      }
     }
 
     evidence.add(declaration.kind);

--- a/packages/@birdcc/core/src/detection/eligibility.ts
+++ b/packages/@birdcc/core/src/detection/eligibility.ts
@@ -1,0 +1,128 @@
+import { basename } from "node:path";
+import { parseBirdConfig, type ParsedBirdDocument } from "@birdcc/parser";
+import type {
+  BirdDeclarationEvidence,
+  BirdDocumentEligibility,
+  BirdDocumentEligibilityOptions,
+} from "./types.js";
+
+const CANONICAL_BIRD_CONFIG_RE = /^\.?bird(?:2|3|6)?\.conf$/i;
+
+const BIRD_PROTOCOL_TYPES = new Set([
+  "aggregator",
+  "babel",
+  "bfd",
+  "bgp",
+  "bmp",
+  "bridge",
+  "device",
+  "direct",
+  "evpn",
+  "kernel",
+  "l3vpn",
+  "mrt",
+  "ospf",
+  "ospf2",
+  "ospf3",
+  "perf",
+  "pipe",
+  "radv",
+  "rip",
+  "rip2",
+  "ripng",
+  "rpki",
+  "static",
+]);
+
+const QUALIFYING_DECLARATION_KINDS = new Set<BirdDeclarationEvidence>([
+  "router-id",
+  "include",
+  "define",
+  "graceful-restart-wait",
+  "hostname-override",
+  "attribute",
+  "table",
+  "mpls-domain",
+  "filter",
+  "function",
+  "template",
+  "protocol",
+  "timeformat",
+  "watchdog",
+]);
+
+const isQualifyingDeclarationKind = (
+  kind: string,
+): kind is BirdDeclarationEvidence =>
+  QUALIFYING_DECLARATION_KINDS.has(kind as BirdDeclarationEvidence);
+
+export const isCanonicalBirdConfigPath = (filePath: string): boolean =>
+  CANONICAL_BIRD_CONFIG_RE.test(basename(filePath));
+
+export const collectBirdDeclarationEvidence = (
+  parsed: ParsedBirdDocument,
+): BirdDeclarationEvidence[] => {
+  const evidence = new Set<BirdDeclarationEvidence>();
+
+  for (const declaration of parsed.program.declarations) {
+    if (!isQualifyingDeclarationKind(declaration.kind)) {
+      continue;
+    }
+
+    if (
+      declaration.kind === "protocol" &&
+      !BIRD_PROTOCOL_TYPES.has(declaration.protocolType.toLowerCase())
+    ) {
+      continue;
+    }
+
+    evidence.add(declaration.kind);
+  }
+
+  return [...evidence].sort();
+};
+
+export const evaluateParsedBirdDocumentEligibility = (
+  parsed: ParsedBirdDocument,
+  options?: BirdDocumentEligibilityOptions,
+): BirdDocumentEligibility => {
+  const declarationKinds = collectBirdDeclarationEvidence(parsed);
+
+  if (options?.explicitMain) {
+    return {
+      eligible: true,
+      reason: "explicit-main",
+      declarationKinds,
+    };
+  }
+
+  if (options?.filePath && isCanonicalBirdConfigPath(options.filePath)) {
+    return {
+      eligible: true,
+      reason: "canonical-filename",
+      declarationKinds,
+    };
+  }
+
+  if (declarationKinds.length > 0) {
+    return {
+      eligible: true,
+      reason: "semantic-evidence",
+      declarationKinds,
+    };
+  }
+
+  return {
+    eligible: false,
+    reason: "no-evidence",
+    declarationKinds,
+  };
+};
+
+export const evaluateBirdDocumentEligibility = async (
+  text: string,
+  options?: BirdDocumentEligibilityOptions,
+): Promise<BirdDocumentEligibility> => {
+  const parsed = await parseBirdConfig(text);
+  return evaluateParsedBirdDocumentEligibility(parsed, options);
+};

--- a/packages/@birdcc/core/src/detection/eligibility.ts
+++ b/packages/@birdcc/core/src/detection/eligibility.ts
@@ -8,6 +8,14 @@ import type {
 
 const CANONICAL_BIRD_CONFIG_RE = /^\.?bird(?:2|3|6)?\.conf$/i;
 
+// Cap the amount of text handed to the Tree-sitter parser when deciding
+// eligibility on evidence alone. Files above this size (e.g. logs or SQL dumps
+// that happen to carry a `.conf` extension) would waste parse time and risk
+// exhausting the extension host, so treat them as having no evidence. Trusted
+// canonical filenames and explicit `main` entries are handled before this and
+// are never subject to the limit.
+const MAX_EVIDENCE_PARSE_LENGTH = 1024 * 1024;
+
 const BIRD_PROTOCOL_TYPES = new Set([
   "aggregator",
   "babel",
@@ -135,6 +143,14 @@ export const evaluateBirdDocumentEligibility = async (
     return {
       eligible: true,
       reason: "canonical-filename",
+      declarationKinds: [],
+    };
+  }
+
+  if (text.length > MAX_EVIDENCE_PARSE_LENGTH) {
+    return {
+      eligible: false,
+      reason: "no-evidence",
       declarationKinds: [],
     };
   }

--- a/packages/@birdcc/core/src/detection/eligibility.ts
+++ b/packages/@birdcc/core/src/detection/eligibility.ts
@@ -123,6 +123,30 @@ export const evaluateBirdDocumentEligibility = async (
   text: string,
   options?: BirdDocumentEligibilityOptions,
 ): Promise<BirdDocumentEligibility> => {
-  const parsed = await parseBirdConfig(text);
-  return evaluateParsedBirdDocumentEligibility(parsed, options);
+  try {
+    const parsed = await parseBirdConfig(text);
+    return evaluateParsedBirdDocumentEligibility(parsed, options);
+  } catch {
+    if (options?.explicitMain) {
+      return {
+        eligible: true,
+        reason: "explicit-main",
+        declarationKinds: [],
+      };
+    }
+
+    if (options?.filePath && isCanonicalBirdConfigPath(options.filePath)) {
+      return {
+        eligible: true,
+        reason: "canonical-filename",
+        declarationKinds: [],
+      };
+    }
+
+    return {
+      eligible: false,
+      reason: "no-evidence",
+      declarationKinds: [],
+    };
+  }
 };

--- a/packages/@birdcc/core/src/detection/eligibility.ts
+++ b/packages/@birdcc/core/src/detection/eligibility.ts
@@ -8,14 +8,6 @@ import type {
 
 const CANONICAL_BIRD_CONFIG_RE = /^\.?bird(?:2|3|6)?\.conf$/i;
 
-// Cap the amount of text handed to the Tree-sitter parser when deciding
-// eligibility on evidence alone. Files above this size (e.g. logs or SQL dumps
-// that happen to carry a `.conf` extension) would waste parse time and risk
-// exhausting the extension host, so treat them as having no evidence. Trusted
-// canonical filenames and explicit `main` entries are handled before this and
-// are never subject to the limit.
-const MAX_EVIDENCE_PARSE_LENGTH = 1024 * 1024;
-
 const BIRD_PROTOCOL_TYPES = new Set([
   "aggregator",
   "babel",
@@ -143,14 +135,6 @@ export const evaluateBirdDocumentEligibility = async (
     return {
       eligible: true,
       reason: "canonical-filename",
-      declarationKinds: [],
-    };
-  }
-
-  if (text.length > MAX_EVIDENCE_PARSE_LENGTH) {
-    return {
-      eligible: false,
-      reason: "no-evidence",
       declarationKinds: [],
     };
   }

--- a/packages/@birdcc/core/src/detection/graph-extras.ts
+++ b/packages/@birdcc/core/src/detection/graph-extras.ts
@@ -82,6 +82,7 @@ export const detectCycles = (
 export const analyzeIncludeGraphExtras = (
   signalsMap: Map<string, ContentSignals>,
   maxParentEscape: number = 2,
+  resolvedEdges?: Map<string, string[]>,
 ): { extras: IncludeGraphExtras; warnings: DetectionWarning[] } => {
   const externalIncludes = new Map<string, string[]>();
   const commentedIncludes = new Map<string, string[]>();
@@ -111,7 +112,7 @@ export const analyzeIncludeGraphExtras = (
   }
 
   // Detect cycles
-  const edges = buildIncludeEdges(signalsMap);
+  const edges = resolvedEdges ?? buildIncludeEdges(signalsMap);
   const cycleWarnings = detectCycles(edges);
   for (const [from, to] of cycleWarnings) {
     warnings.push({

--- a/packages/@birdcc/core/src/detection/include-graph.ts
+++ b/packages/@birdcc/core/src/detection/include-graph.ts
@@ -54,11 +54,13 @@ export const resolveIncludeGraph = (
         continue;
       }
 
-      const matches = /[*?]/.test(relativePattern)
-        ? knownPaths.filter((path) => globToRegExp(relativePattern).test(path))
-        : knownPathSet.has(relativePattern)
-          ? [relativePattern]
-          : [];
+      let matches: string[];
+      if (/[*?]/.test(relativePattern)) {
+        const pattern = globToRegExp(relativePattern);
+        matches = knownPaths.filter((path) => pattern.test(path));
+      } else {
+        matches = knownPathSet.has(relativePattern) ? [relativePattern] : [];
+      }
 
       if (matches.length === 0) {
         missing += 1;

--- a/packages/@birdcc/core/src/detection/include-graph.ts
+++ b/packages/@birdcc/core/src/detection/include-graph.ts
@@ -91,7 +91,7 @@ export const collectReachableIncludes = (
   const queue = [...(edges.get(entryPath) ?? [])];
 
   while (queue.length > 0) {
-    const current = queue.shift()!;
+    const current = queue.pop()!;
     if (current === entryPath || visited.has(current)) {
       continue;
     }

--- a/packages/@birdcc/core/src/detection/include-graph.ts
+++ b/packages/@birdcc/core/src/detection/include-graph.ts
@@ -12,6 +12,7 @@ const normalizeRelativePath = (path: string): string =>
 
 const isWithinRoot = (relativePath: string): boolean =>
   relativePath.length > 0 &&
+  relativePath !== ".." &&
   !relativePath.startsWith("../") &&
   !isAbsolute(relativePath);
 

--- a/packages/@birdcc/core/src/detection/include-graph.ts
+++ b/packages/@birdcc/core/src/detection/include-graph.ts
@@ -1,0 +1,102 @@
+import { dirname, isAbsolute, relative, resolve } from "node:path";
+import type { ContentSignals } from "./types.js";
+
+export interface ResolvedIncludeGraph {
+  edges: Map<string, string[]>;
+  missingBySource: Map<string, number>;
+  includedByCount: Map<string, number>;
+}
+
+const normalizeRelativePath = (path: string): string =>
+  path.replaceAll("\\", "/").replace(/^\.\//, "");
+
+const isWithinRoot = (relativePath: string): boolean =>
+  relativePath.length > 0 &&
+  !relativePath.startsWith("../") &&
+  !isAbsolute(relativePath);
+
+const globToRegExp = (glob: string): RegExp => {
+  let output = "";
+  for (const character of glob) {
+    if (character === "*") {
+      output += "[^/]*";
+    } else if (character === "?") {
+      output += "[^/]";
+    } else {
+      output += character.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+    }
+  }
+  return new RegExp(`^${output}$`);
+};
+
+export const resolveIncludeGraph = (
+  root: string,
+  signalsMap: Map<string, ContentSignals>,
+): ResolvedIncludeGraph => {
+  const knownPaths = [...signalsMap.keys()].map(normalizeRelativePath).sort();
+  const knownPathSet = new Set(knownPaths);
+  const edges = new Map<string, string[]>();
+  const missingBySource = new Map<string, number>();
+  const includedByCount = new Map<string, number>();
+
+  for (const [rawSource, signals] of signalsMap) {
+    const source = normalizeRelativePath(rawSource);
+    const targets = new Set<string>();
+    let missing = 0;
+
+    for (const includePath of signals.includeStatements) {
+      const absolutePattern = resolve(root, dirname(source), includePath);
+      const relativePattern = normalizeRelativePath(
+        relative(root, absolutePattern),
+      );
+      if (!isWithinRoot(relativePattern)) {
+        missing += 1;
+        continue;
+      }
+
+      const matches = /[*?]/.test(relativePattern)
+        ? knownPaths.filter((path) => globToRegExp(relativePattern).test(path))
+        : knownPathSet.has(relativePattern)
+          ? [relativePattern]
+          : [];
+
+      if (matches.length === 0) {
+        missing += 1;
+        continue;
+      }
+
+      for (const match of matches) {
+        targets.add(match);
+      }
+    }
+
+    const sortedTargets = [...targets].sort();
+    edges.set(source, sortedTargets);
+    missingBySource.set(source, missing);
+    for (const target of sortedTargets) {
+      includedByCount.set(target, (includedByCount.get(target) ?? 0) + 1);
+    }
+  }
+
+  return { edges, missingBySource, includedByCount };
+};
+
+export const collectReachableIncludes = (
+  entryPath: string,
+  edges: Map<string, string[]>,
+): Set<string> => {
+  const visited = new Set<string>();
+  const queue = [...(edges.get(entryPath) ?? [])];
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (current === entryPath || visited.has(current)) {
+      continue;
+    }
+
+    visited.add(current);
+    queue.push(...(edges.get(current) ?? []));
+  }
+
+  return visited;
+};

--- a/packages/@birdcc/core/src/detection/index.ts
+++ b/packages/@birdcc/core/src/detection/index.ts
@@ -7,6 +7,10 @@
 
 export type {
   ContentSignals,
+  BirdDeclarationEvidence,
+  BirdDocumentEligibility,
+  BirdDocumentEligibilityOptions,
+  BirdDocumentEligibilityReason,
   DetectionKind,
   DetectionOptions,
   DetectionResult,
@@ -17,11 +21,22 @@ export type {
   SignalRecord,
 } from "./types.js";
 
+export {
+  collectBirdDeclarationEvidence,
+  evaluateBirdDocumentEligibility,
+  evaluateParsedBirdDocumentEligibility,
+  isCanonicalBirdConfigPath,
+} from "./eligibility.js";
+
 import { collectWithShallowPriority } from "./collector.js";
-import { scanFileContent } from "./content-scanner.js";
+import { analyzeFileContent } from "./content-scanner.js";
 import { classifyFileRole } from "./role-classifier.js";
 import { scoreWithContent } from "./scorer.js";
 import { analyzeIncludeGraphExtras } from "./graph-extras.js";
+import {
+  collectReachableIncludes,
+  resolveIncludeGraph,
+} from "./include-graph.js";
 import {
   applyGraphStats,
   detectMonorepoMode,
@@ -36,6 +51,13 @@ import type {
 } from "./types.js";
 
 const AMBIGUITY_THRESHOLD = 30;
+const AUTO_SELECTION_CONFIDENCE = 70;
+
+const compareCandidates = (a: EntryCandidate, b: EntryCandidate): number =>
+  b.score - a.score || a.path.localeCompare(b.path);
+
+const normalizeRelativePath = (path: string): string =>
+  path.replaceAll("\\", "/").replace(/^\.\//, "");
 
 /**
  * Detect BIRD2 project entry points by scanning the file system.
@@ -74,12 +96,24 @@ export const sniffProjectEntrypoints = async (
 
   // Trim to maxCandidates (prefer shallow + canonical)
   const sortedFiles = [...collected.files].sort((a, b) => {
+    const explicitMain = opts?.explicitMain
+      ? normalizeRelativePath(opts.explicitMain)
+      : undefined;
+    const aIsExplicit = explicitMain === a.relativePath;
+    const bIsExplicit = explicitMain === b.relativePath;
+    if (aIsExplicit !== bIsExplicit) return aIsExplicit ? -1 : 1;
     // Canonical first
     if (a.isCanonical !== b.isCanonical) return a.isCanonical ? -1 : 1;
     // Then by depth (shallower first)
-    return a.depth - b.depth;
+    return a.depth - b.depth || a.relativePath.localeCompare(b.relativePath);
   });
   const trimmedFiles = sortedFiles.slice(0, maxCandidates);
+  if (collected.files.length > maxCandidates) {
+    warnings.push({
+      code: "detection/candidate-limit-reached",
+      message: `Only the first ${maxCandidates} of ${collected.files.length} configuration candidates were analyzed.`,
+    });
+  }
 
   // ── Phase 2: Content scanning + scoring ───────────────────────────
   const signalsMap = new Map<string, ContentSignals>();
@@ -91,79 +125,142 @@ export const sniffProjectEntrypoints = async (
     const batch = trimmedFiles.slice(i, i + BATCH_SIZE);
     const results = await Promise.all(
       batch.map(async (file) => {
-        const signals = await scanFileContent(root, file.relativePath);
-        return { file, signals };
+        const analysis = await analyzeFileContent(
+          root,
+          file.relativePath,
+          opts?.explicitMain !== undefined &&
+            normalizeRelativePath(opts.explicitMain) ===
+              normalizeRelativePath(file.relativePath),
+        );
+        return { file, analysis };
       }),
     );
 
-    for (const { file, signals } of results) {
-      if (signals) {
-        signalsMap.set(file.relativePath, signals);
+    for (const { file, analysis } of results) {
+      const signals = analysis?.signals ?? null;
+      if (analysis) {
+        signalsMap.set(
+          normalizeRelativePath(file.relativePath),
+          analysis.signals,
+        );
       }
 
-      const role = classifyFileRole(file.relativePath, signals);
+      let role = classifyFileRole(file.relativePath, signals);
+      const declarationKinds = analysis?.eligibility.declarationKinds ?? [];
+      if (
+        role === "unknown" &&
+        declarationKinds.length > 0 &&
+        declarationKinds.every((kind) =>
+          ["define", "filter", "function", "table", "template"].includes(kind),
+        )
+      ) {
+        role = "library";
+      }
       const candidate = scoreWithContent(file, signals, role);
+      candidate.qualified = analysis?.eligibility.eligible ?? false;
+      candidate.declarationKinds = declarationKinds;
+      candidate.includedByCount = 0;
+
+      if (analysis?.eligibility.eligible) {
+        const delta = file.isCanonical ? 0 : 15;
+        candidate.score += delta;
+        candidate.signals.push({
+          name: `bird-eligibility(${analysis.eligibility.reason})`,
+          delta,
+        });
+      } else {
+        candidate.role = "external";
+        candidate.signals.push({
+          name: "rejected-no-bird-evidence",
+          delta: 0,
+        });
+      }
       candidates.push(candidate);
     }
   }
 
   // ── Phase 3: Include-graph analysis ───────────────────────────────
+  const includeGraph = resolveIncludeGraph(root, signalsMap);
   if (signalsMap.size > 0) {
     // Graph extras: escape detection, cycle detection
-    const graphAnalysis = analyzeIncludeGraphExtras(signalsMap);
+    const graphAnalysis = analyzeIncludeGraphExtras(
+      signalsMap,
+      2,
+      includeGraph.edges,
+    );
     warnings.push(...graphAnalysis.warnings);
+
+    for (const candidate of candidates) {
+      candidate.includedByCount =
+        includeGraph.includedByCount.get(candidate.path) ?? 0;
+    }
 
     // Filter to viable entry candidates for graph analysis
     const viableEntries = candidates
-      .filter((c) => c.role !== "library" && c.score > 0)
-      .sort((a, b) => b.score - a.score)
+      .filter((c) => c.qualified && c.role !== "library" && c.score > 0)
+      .sort(compareCandidates)
       .slice(0, 5);
 
     // For top candidates, compute cross-file stats from their include lists
     for (const candidate of viableEntries) {
-      const signals = signalsMap.get(candidate.path);
-      if (signals) {
-        // Count include coverage (simplified — full graph would use resolveCrossFileReferences)
-        const visited = new Set<string>();
-        const queue = [...signals.includeStatements];
+      const visited = collectReachableIncludes(
+        candidate.path,
+        includeGraph.edges,
+      );
+      const missingIncludes = [candidate.path, ...visited].reduce(
+        (count, path) => count + (includeGraph.missingBySource.get(path) ?? 0),
+        0,
+      );
 
-        while (queue.length > 0) {
-          const inc = queue.shift()!;
-          if (visited.has(inc)) continue;
-          visited.add(inc);
-
-          const incSignals = signalsMap.get(inc);
-          if (incSignals) {
-            queue.push(...incSignals.includeStatements);
-          }
-        }
-
-        const missingIncludes = signals.includeStatements.filter(
-          (inc) => !signalsMap.has(inc),
-        ).length;
-
-        applyGraphStats(candidate, visited.size, missingIncludes, false);
-      }
+      applyGraphStats(candidate, visited.size, missingIncludes, false);
     }
 
     // Propagate scores along include edges
-    propagateScores(candidates, signalsMap);
+    propagateScores(candidates, includeGraph.edges);
   }
 
   // ── Decision ──────────────────────────────────────────────────────
   // Sort by score descending
-  candidates.sort((a, b) => b.score - a.score);
+  candidates.sort(compareCandidates);
+
+  const qualifiedCandidates = candidates.filter((candidate) =>
+    Boolean(candidate.qualified),
+  );
+  if (qualifiedCandidates.length === 0) {
+    return {
+      kind: "not-found",
+      confidence: 100,
+      primary: null,
+      candidates,
+      warnings: [
+        ...warnings,
+        {
+          code: "detection/no-bird-evidence",
+          message:
+            "Configuration files were found, but none contained parsed BIRD declarations.",
+        },
+      ],
+    };
+  }
 
   // Remove library/fragment from entry competition (but keep in candidates list)
   const entryContenders = candidates.filter(
-    (c) => c.role !== "library" && c.role !== "fragment",
+    (c) =>
+      c.qualified &&
+      (c.includedByCount ?? 0) === 0 &&
+      (c.signals.some(
+        (signal) =>
+          signal.name === "canonical-name" ||
+          signal.name === "bird-eligibility(explicit-main)",
+      ) ||
+        (c.role !== "library" && c.role !== "fragment")),
   );
 
   if (entryContenders.length === 0) {
     return {
       kind: "not-found",
       confidence: 50,
-      primary: candidates[0] ?? null,
+      primary: null,
       candidates,
       warnings: [
         ...warnings,
@@ -177,7 +274,11 @@ export const sniffProjectEntrypoints = async (
   }
 
   // Check for monorepo patterns
-  const monoCheck = detectMonorepoMode(entryContenders, signalsMap);
+  const monoCheck = detectMonorepoMode(
+    entryContenders,
+    includeGraph.edges,
+    qualifiedCandidates,
+  );
   if (
     monoCheck.kind === "monorepo-multi-entry" ||
     monoCheck.kind === "monorepo-multi-role"
@@ -219,4 +320,24 @@ export const sniffProjectEntrypoints = async (
     candidates,
     warnings,
   };
+};
+
+/**
+ * Return an entry only when a detection result is safe for unattended use.
+ */
+export const selectAutoDetectedEntry = (
+  result: DetectionResult,
+): EntryCandidate | null => {
+  if (
+    result.kind === "single" &&
+    result.confidence >= AUTO_SELECTION_CONFIDENCE
+  ) {
+    return result.primary;
+  }
+
+  if (result.kind === "monorepo-multi-role") {
+    return result.primary;
+  }
+
+  return null;
 };

--- a/packages/@birdcc/core/src/detection/topology.ts
+++ b/packages/@birdcc/core/src/detection/topology.ts
@@ -153,8 +153,7 @@ export const detectMonorepoMode = (
     const libraryGroups = new Map<string, Set<string>>();
     for (const candidate of allCandidates) {
       if (candidate.role !== "library") continue;
-      const segments = candidate.path.split("/");
-      const fileName = segments[segments.length - 1] ?? candidate.path;
+      const fileName = candidate.path.split("/").at(-1) ?? candidate.path;
       const directories = libraryGroups.get(fileName) ?? new Set<string>();
       directories.add(getCandidateDirectory(candidate.path));
       libraryGroups.set(fileName, directories);

--- a/packages/@birdcc/core/src/detection/topology.ts
+++ b/packages/@birdcc/core/src/detection/topology.ts
@@ -244,9 +244,7 @@ export const detectMonorepoMode = (
 
   // Fallback to multi-entry if multiple high-score entries exist
   if (entries.length > 1 && dirGroups.size > 1) {
-    const workspaces = [
-      ...new Set(entries.map((entry) => getCandidateDirectory(entry.path))),
-    ].sort();
+    const workspaces = [...dirGroups.keys()].sort();
     return { kind: "monorepo-multi-entry", workspaces, warnings };
   }
 

--- a/packages/@birdcc/core/src/detection/topology.ts
+++ b/packages/@birdcc/core/src/detection/topology.ts
@@ -14,6 +14,10 @@ import type {
 const PROPAGATION_DECAY = 0.8;
 const MAX_PROPAGATION_DEPTH = 3;
 
+/** Return a stable, POSIX-style directory for a candidate on every platform. */
+export const getCandidateDirectory = (filePath: string): string =>
+  dirname(filePath.replaceAll("\\", "/")).replaceAll("\\", "/");
+
 /**
  * Propagate positive signal scores from included files back to their includers.
  *
@@ -151,7 +155,7 @@ export const detectMonorepoMode = (
       if (candidate.role !== "library") continue;
       const fileName = candidate.path.split("/").at(-1) ?? candidate.path;
       const directories = libraryGroups.get(fileName) ?? new Set<string>();
-      directories.add(dirname(candidate.path));
+      directories.add(getCandidateDirectory(candidate.path));
       libraryGroups.set(fileName, directories);
     }
 
@@ -164,7 +168,7 @@ export const detectMonorepoMode = (
           ...new Set(
             allCandidates
               .filter((candidate) => candidate.role === "library")
-              .map((candidate) => dirname(candidate.path)),
+              .map((candidate) => getCandidateDirectory(candidate.path)),
           ),
         ].sort(),
         warnings,
@@ -179,7 +183,7 @@ export const detectMonorepoMode = (
   // Group by immediate parent directory
   const dirGroups = new Map<string, EntryCandidate[]>();
   for (const entry of entries) {
-    const dir = dirname(entry.path);
+    const dir = getCandidateDirectory(entry.path);
     if (!dirGroups.has(dir)) {
       dirGroups.set(dir, []);
     }
@@ -228,7 +232,7 @@ export const detectMonorepoMode = (
   if (dominant.length === 1 && sorted.length > 1) {
     // Check if non-dominant files are variable/library files
     const others = sorted.slice(1);
-    const otherDirs = new Set(others.map((o) => dirname(o.path)));
+    const otherDirs = new Set(others.map((o) => getCandidateDirectory(o.path)));
     if (otherDirs.size > 1) {
       return {
         kind: "monorepo-multi-role",
@@ -240,7 +244,9 @@ export const detectMonorepoMode = (
 
   // Fallback to multi-entry if multiple high-score entries exist
   if (entries.length > 1 && dirGroups.size > 1) {
-    const workspaces = [...new Set(entries.map((e) => dirname(e.path)))].sort();
+    const workspaces = [
+      ...new Set(entries.map((entry) => getCandidateDirectory(entry.path))),
+    ].sort();
     return { kind: "monorepo-multi-entry", workspaces, warnings };
   }
 

--- a/packages/@birdcc/core/src/detection/topology.ts
+++ b/packages/@birdcc/core/src/detection/topology.ts
@@ -4,8 +4,8 @@
  */
 
 import { dirname } from "node:path";
+import { collectReachableIncludes } from "./include-graph.js";
 import type {
-  ContentSignals,
   DetectionKind,
   DetectionWarning,
   EntryCandidate,
@@ -22,12 +22,12 @@ const MAX_PROPAGATION_DEPTH = 3;
  */
 export const propagateScores = (
   candidates: EntryCandidate[],
-  signalsMap: Map<string, ContentSignals>,
+  edges: Map<string, string[]>,
 ): void => {
   // Build reverse edge map: included → includers
   const reverseEdges = new Map<string, Set<string>>();
-  for (const [filePath, signals] of signalsMap) {
-    for (const inc of signals.includeStatements) {
+  for (const [filePath, includes] of edges) {
+    for (const inc of includes) {
       if (!reverseEdges.has(inc)) {
         reverseEdges.set(inc, new Set());
       }
@@ -133,7 +133,8 @@ export const applyGraphStats = (
  */
 export const detectMonorepoMode = (
   candidates: EntryCandidate[],
-  signalsMap: Map<string, ContentSignals>,
+  edges: Map<string, string[]>,
+  allCandidates: EntryCandidate[] = candidates,
 ): {
   kind: DetectionKind;
   workspaces: string[];
@@ -142,7 +143,34 @@ export const detectMonorepoMode = (
   const warnings: DetectionWarning[] = [];
 
   // Filter to entry-role candidates with viable scores
-  const entries = candidates.filter((c) => c.role === "entry" && c.score > 0);
+  const entries = candidates.filter((candidate) => candidate.score > 0);
+
+  if (entries.length === 1) {
+    const libraryGroups = new Map<string, Set<string>>();
+    for (const candidate of allCandidates) {
+      if (candidate.role !== "library") continue;
+      const fileName = candidate.path.split("/").at(-1) ?? candidate.path;
+      const directories = libraryGroups.get(fileName) ?? new Set<string>();
+      directories.add(dirname(candidate.path));
+      libraryGroups.set(fileName, directories);
+    }
+
+    if (
+      [...libraryGroups.values()].some((directories) => directories.size > 1)
+    ) {
+      return {
+        kind: "monorepo-multi-role",
+        workspaces: [
+          ...new Set(
+            allCandidates
+              .filter((candidate) => candidate.role === "library")
+              .map((candidate) => dirname(candidate.path)),
+          ),
+        ].sort(),
+        warnings,
+      };
+    }
+  }
 
   if (entries.length <= 1) {
     return { kind: "single", workspaces: [], warnings };
@@ -162,11 +190,8 @@ export const detectMonorepoMode = (
   const coverageSets = new Map<string, Set<string>>();
   for (const entry of entries) {
     const coverage = new Set<string>();
-    const signals = signalsMap.get(entry.path);
-    if (signals) {
-      for (const inc of signals.includeStatements) {
-        coverage.add(inc);
-      }
+    for (const includedPath of collectReachableIncludes(entry.path, edges)) {
+      coverage.add(includedPath);
     }
     coverageSets.set(entry.path, coverage);
   }
@@ -194,7 +219,9 @@ export const detectMonorepoMode = (
 
   // multi-role: single main entry + multiple vars in different dirs
   // Check if there's one dominant entry and others are library-like
-  const sorted = [...entries].sort((a, b) => b.score - a.score);
+  const sorted = [...entries].sort(
+    (a, b) => b.score - a.score || a.path.localeCompare(b.path),
+  );
   const topScore = sorted[0].score;
   const dominant = sorted.filter((c) => c.score >= topScore * 0.7);
 
@@ -212,7 +239,7 @@ export const detectMonorepoMode = (
   }
 
   // Fallback to multi-entry if multiple high-score entries exist
-  if (entries.length > 1) {
+  if (entries.length > 1 && dirGroups.size > 1) {
     const workspaces = [...new Set(entries.map((e) => dirname(e.path)))].sort();
     return { kind: "monorepo-multi-entry", workspaces, warnings };
   }

--- a/packages/@birdcc/core/src/detection/topology.ts
+++ b/packages/@birdcc/core/src/detection/topology.ts
@@ -153,7 +153,8 @@ export const detectMonorepoMode = (
     const libraryGroups = new Map<string, Set<string>>();
     for (const candidate of allCandidates) {
       if (candidate.role !== "library") continue;
-      const fileName = candidate.path.split("/").at(-1) ?? candidate.path;
+      const segments = candidate.path.split("/");
+      const fileName = segments[segments.length - 1] ?? candidate.path;
       const directories = libraryGroups.get(fileName) ?? new Set<string>();
       directories.add(getCandidateDirectory(candidate.path));
       libraryGroups.set(fileName, directories);

--- a/packages/@birdcc/core/src/detection/types.ts
+++ b/packages/@birdcc/core/src/detection/types.ts
@@ -34,6 +34,12 @@ export interface EntryCandidate {
   role: FileRole;
   visitedCount: number;
   missingIncludes: number;
+  /** Whether the file contains parsed BIRD declarations or is explicitly trusted. */
+  qualified?: boolean;
+  /** Parsed declaration kinds used as positive BIRD language evidence. */
+  declarationKinds?: BirdDeclarationEvidence[];
+  /** Number of other scanned files that include this candidate. */
+  includedByCount?: number;
 }
 
 export interface SignalRecord {
@@ -54,6 +60,41 @@ export interface DetectionOptions {
   exclude?: string[]; // additional glob patterns
   forceRescan?: boolean;
   followSymlinks?: boolean; // default: false
+  /** Explicitly configured main file, relative to the detection root. */
+  explicitMain?: string;
+}
+
+export type BirdDeclarationEvidence =
+  | "router-id"
+  | "include"
+  | "define"
+  | "graceful-restart-wait"
+  | "hostname-override"
+  | "attribute"
+  | "table"
+  | "mpls-domain"
+  | "filter"
+  | "function"
+  | "template"
+  | "protocol"
+  | "timeformat"
+  | "watchdog";
+
+export type BirdDocumentEligibilityReason =
+  | "canonical-filename"
+  | "explicit-main"
+  | "semantic-evidence"
+  | "no-evidence";
+
+export interface BirdDocumentEligibility {
+  eligible: boolean;
+  reason: BirdDocumentEligibilityReason;
+  declarationKinds: BirdDeclarationEvidence[];
+}
+
+export interface BirdDocumentEligibilityOptions {
+  filePath?: string;
+  explicitMain?: boolean;
 }
 
 /** Signals extracted from lightweight content scanning (v0.2) */

--- a/packages/@birdcc/core/src/index.ts
+++ b/packages/@birdcc/core/src/index.ts
@@ -49,8 +49,19 @@ export {
 } from "./type-inference.js";
 
 export { parseBirdValidationOutput } from "./bird-validation-parser.js";
-export { sniffProjectEntrypoints } from "./detection/index.js";
+export {
+  collectBirdDeclarationEvidence,
+  evaluateBirdDocumentEligibility,
+  evaluateParsedBirdDocumentEligibility,
+  isCanonicalBirdConfigPath,
+  selectAutoDetectedEntry,
+  sniffProjectEntrypoints,
+} from "./detection/index.js";
 export type {
+  BirdDeclarationEvidence,
+  BirdDocumentEligibility,
+  BirdDocumentEligibilityOptions,
+  BirdDocumentEligibilityReason,
   ContentSignals,
   DetectionKind,
   DetectionOptions,

--- a/packages/@birdcc/core/test/content-scanner-resilience.test.ts
+++ b/packages/@birdcc/core/test/content-scanner-resilience.test.ts
@@ -1,0 +1,33 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  parseBirdConfig: vi.fn(),
+}));
+
+vi.mock("@birdcc/parser", () => ({
+  parseBirdConfig: mocks.parseBirdConfig,
+}));
+
+import { analyzeFileContent } from "../src/detection/content-scanner.js";
+
+describe("content scanner resilience", () => {
+  let root = "";
+
+  afterEach(async () => {
+    mocks.parseBirdConfig.mockReset();
+    if (root) {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("isolates parser failures to the affected candidate", async () => {
+    root = await mkdtemp(join(tmpdir(), "birdcc-content-scan-"));
+    await writeFile(join(root, "broken.conf"), "protocol device {}", "utf8");
+    mocks.parseBirdConfig.mockRejectedValueOnce(new Error("parser failed"));
+
+    await expect(analyzeFileContent(root, "broken.conf")).resolves.toBeNull();
+  });
+});

--- a/packages/@birdcc/core/test/content-scanner-resilience.test.ts
+++ b/packages/@birdcc/core/test/content-scanner-resilience.test.ts
@@ -31,6 +31,27 @@ describe("content scanner resilience", () => {
     await expect(analyzeFileContent(root, "broken.conf")).resolves.toBeNull();
   });
 
+  it.each([
+    ["canonical filename", "bird.conf", false, "canonical-filename"],
+    ["explicit main", "custom.conf", true, "explicit-main"],
+  ])(
+    "preserves the %s escape hatch when the parser fails",
+    async (_name, fileName, explicitMain, reason) => {
+      root = await mkdtemp(join(tmpdir(), "birdcc-content-scan-"));
+      await writeFile(join(root, fileName), "protocol device {", "utf8");
+      mocks.parseBirdConfig.mockRejectedValueOnce(new Error("parser failed"));
+
+      const analysis = await analyzeFileContent(root, fileName, explicitMain);
+
+      expect(analysis?.eligibility).toEqual({
+        eligible: true,
+        reason,
+        declarationKinds: [],
+      });
+      expect(analysis?.signals.hasProtocolDevice).toBe(true);
+    },
+  );
+
   it("ignores a recovered include declaration without a string path", async () => {
     root = await mkdtemp(join(tmpdir(), "birdcc-content-scan-"));
     await writeFile(join(root, "recovered.conf"), "include;", "utf8");

--- a/packages/@birdcc/core/test/content-scanner-resilience.test.ts
+++ b/packages/@birdcc/core/test/content-scanner-resilience.test.ts
@@ -30,4 +30,18 @@ describe("content scanner resilience", () => {
 
     await expect(analyzeFileContent(root, "broken.conf")).resolves.toBeNull();
   });
+
+  it("ignores a recovered include declaration without a string path", async () => {
+    root = await mkdtemp(join(tmpdir(), "birdcc-content-scan-"));
+    await writeFile(join(root, "recovered.conf"), "include;", "utf8");
+    mocks.parseBirdConfig.mockResolvedValueOnce({
+      program: {
+        declarations: [{ kind: "include", path: undefined }],
+      },
+    });
+
+    const analysis = await analyzeFileContent(root, "recovered.conf");
+
+    expect(analysis?.signals.includeStatements).toEqual([]);
+  });
 });

--- a/packages/@birdcc/core/test/detection.test.ts
+++ b/packages/@birdcc/core/test/detection.test.ts
@@ -6,6 +6,7 @@ import {
   selectAutoDetectedEntry,
   sniffProjectEntrypoints,
 } from "../src/detection/index.js";
+import { getCandidateDirectory } from "../src/detection/topology.js";
 
 /**
  * Helper: create a temp directory with a given file structure.
@@ -542,5 +543,14 @@ protocol device {}
       expect.arrayContaining(["bird.conf", "sites/asia/tokyo/bird.conf"]),
     );
     expect(selectAutoDetectedEntry(result)).toBeNull();
+  });
+});
+
+describe("candidate path normalization", () => {
+  it("returns stable POSIX directories for Windows candidate paths", () => {
+    expect(getCandidateDirectory("sites\\tokyo\\bird.conf")).toBe(
+      "sites/tokyo",
+    );
+    expect(getCandidateDirectory("sites/tokyo/bird.conf")).toBe("sites/tokyo");
   });
 });

--- a/packages/@birdcc/core/test/detection.test.ts
+++ b/packages/@birdcc/core/test/detection.test.ts
@@ -2,7 +2,10 @@ import { mkdir, writeFile, rm, mkdtemp } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it, afterEach } from "vitest";
-import { sniffProjectEntrypoints } from "../src/detection/index.js";
+import {
+  selectAutoDetectedEntry,
+  sniffProjectEntrypoints,
+} from "../src/detection/index.js";
 
 /**
  * Helper: create a temp directory with a given file structure.
@@ -192,7 +195,7 @@ protocol device {}
 
     const result = await sniffProjectEntrypoints(root);
     // Both have similar scores at same depth with no canonical name
-    expect(["single-ambiguous", "monorepo-multi-entry"]).toContain(result.kind);
+    expect(result.kind).toBe("single-ambiguous");
   });
 
   // ── v0.3 Tests ──────────────────────────────────────────────────
@@ -214,7 +217,7 @@ protocol kernel { ipv4 { export all; }; }
     expect(result.primary!.path).toBe("bird.conf");
   });
 
-  it("#11 include glob with 3 files → visitedCount counted correctly", async () => {
+  it("#11 three direct includes → visitedCount counted correctly", async () => {
     root = await createFixture({
       "bird.conf": `
 router id 10.0.0.1;
@@ -244,6 +247,7 @@ protocol static {
 
     const result = await sniffProjectEntrypoints(root);
     expect(result.primary!.path).toBe("bird.conf");
+    expect(result.primary!.visitedCount).toBe(3);
     expect(result.kind).toBe("single");
   });
 
@@ -326,11 +330,11 @@ define ROUTER_NAME = "router2";
     });
 
     const result = await sniffProjectEntrypoints(root);
-    // This should detect the pattern — either multi-role or single with the root entry
+    expect(result.kind).toBe("monorepo-multi-role");
     expect(result.primary!.path).toBe("bird.conf");
   });
 
-  it("#16 > 1000 .conf files → degrades gracefully without timeout", async () => {
+  it("#16 200 generated .conf files → degrades gracefully without timeout", async () => {
     // Create a large number of files
     const files: Record<string, string> = {
       "bird.conf": `
@@ -377,5 +381,166 @@ protocol device {}
     const result = await sniffProjectEntrypoints(root);
     expect(result.kind).toBe("single");
     expect(result.primary?.path).toBe("sites/asia/tokyo/bird.conf");
+  });
+
+  it.each([
+    ["nginx.conf", "events {}\nhttp { server { listen 80; } }"],
+    [
+      "httpd.conf",
+      "<VirtualHost *:80>\nServerName example.test\n</VirtualHost>",
+    ],
+    ["haproxy.conf", "global\n  daemon\ndefaults\n  mode http"],
+    ["redis.conf", "maxmemory 2gb\nsave 60 1"],
+    ["prometheus.conf", "global:\n  scrape_interval: 15s"],
+    ["service.conf", "[Service]\nExecStart=/usr/bin/example"],
+    ["empty.conf", ""],
+    ["comments.conf", "# protocol device {}"],
+    ["strings.conf", 'message = "protocol device {}";'],
+    ["random.conf", "this is not a routing configuration"],
+    ["external.conf", 'protocol http { endpoint = "https://example.test"; }'],
+  ])("rejects foreign-only candidate %s", async (fileName, content) => {
+    root = await createFixture({ [fileName]: content });
+
+    const result = await sniffProjectEntrypoints(root);
+
+    expect(result.kind).toBe("not-found");
+    expect(result.primary).toBeNull();
+    expect(result.candidates).toHaveLength(1);
+    expect(result.candidates[0]).toMatchObject({
+      path: fileName,
+      qualified: false,
+      role: "external",
+    });
+    expect(result.warnings).toContainEqual(
+      expect.objectContaining({ code: "detection/no-bird-evidence" }),
+    );
+  });
+
+  it.each(["bird.conf", "bird2.conf", "bird3.conf", "bird6.conf"])(
+    "accepts empty canonical entry %s",
+    async (fileName) => {
+      root = await createFixture({ [fileName]: "" });
+
+      const result = await sniffProjectEntrypoints(root);
+
+      expect(result.kind).toBe("single");
+      expect(result.primary?.path).toBe(fileName);
+      expect(selectAutoDetectedEntry(result)?.path).toBe(fileName);
+    },
+  );
+
+  it("accepts an explicitly configured empty main", async () => {
+    root = await createFixture({ "custom.conf": "" });
+
+    const result = await sniffProjectEntrypoints(root, {
+      explicitMain: "./custom.conf",
+    });
+
+    expect(result.kind).toBe("single");
+    expect(result.primary?.path).toBe("custom.conf");
+  });
+
+  it("resolves includes relative to the includer and excludes included fragments", async () => {
+    root = await createFixture({
+      "routers/main.conf": [
+        'include "../shared/vars.conf";',
+        'include "../protocols/*.conf";',
+      ].join("\n"),
+      "shared/vars.conf": "define LOCAL_AS = 65001;",
+      "protocols/bgp.conf": "protocol bgp edge { local as LOCAL_AS; }",
+      "protocols/device.conf": "protocol device {}",
+    });
+
+    const result = await sniffProjectEntrypoints(root);
+
+    expect(result.primary).toMatchObject({
+      path: "routers/main.conf",
+      visitedCount: 3,
+      missingIncludes: 0,
+    });
+    expect(
+      result.candidates.find(
+        (candidate) => candidate.path === "protocols/bgp.conf",
+      ),
+    ).toMatchObject({ includedByCount: 1 });
+  });
+
+  it("does not reward missing includes", async () => {
+    root = await createFixture({
+      "main.conf": 'include "missing/*.conf";',
+    });
+
+    const result = await sniffProjectEntrypoints(root);
+
+    expect(result.primary).toMatchObject({
+      path: "main.conf",
+      visitedCount: 0,
+      missingIncludes: 1,
+    });
+    expect(
+      result.primary?.signals.some((signal) =>
+        signal.name.startsWith("visited-count"),
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps mixed foreign and BIRD candidates explainable", async () => {
+    root = await createFixture({
+      "nginx.conf": "events {}\nhttp { server { listen 80; } }",
+      "main.conf": "protocol device {}",
+    });
+
+    const result = await sniffProjectEntrypoints(root);
+
+    expect(result.primary?.path).toBe("main.conf");
+    expect(
+      result.candidates.find((candidate) => candidate.path === "nginx.conf"),
+    ).toMatchObject({ qualified: false, role: "external" });
+  });
+
+  it("uses a stable path tie-break and refuses ambiguous auto-selection", async () => {
+    root = await createFixture({
+      "a.conf": "protocol device {}",
+      "b.conf": "protocol device {}",
+    });
+
+    const first = await sniffProjectEntrypoints(root);
+    const second = await sniffProjectEntrypoints(root);
+
+    expect(first.kind).toBe("single-ambiguous");
+    expect(first.primary?.path).toBe("a.conf");
+    expect(second.candidates.map((candidate) => candidate.path)).toEqual(
+      first.candidates.map((candidate) => candidate.path),
+    );
+    expect(selectAutoDetectedEntry(first)).toBeNull();
+  });
+
+  it("reports candidate truncation explicitly", async () => {
+    root = await createFixture({
+      "a.conf": "protocol device {}",
+      "b.conf": "protocol kernel {}",
+    });
+
+    const result = await sniffProjectEntrypoints(root, { maxCandidates: 1 });
+
+    expect(result.candidates).toHaveLength(1);
+    expect(result.warnings).toContainEqual(
+      expect.objectContaining({ code: "detection/candidate-limit-reached" }),
+    );
+  });
+
+  it("does not let a shallow canonical entry hide a deep instance", async () => {
+    root = await createFixture({
+      "bird.conf": "protocol device {}",
+      "sites/asia/tokyo/bird.conf": "protocol kernel {}",
+    });
+
+    const result = await sniffProjectEntrypoints(root);
+
+    expect(result.kind).toBe("monorepo-multi-entry");
+    expect(result.candidates.map((candidate) => candidate.path)).toEqual(
+      expect.arrayContaining(["bird.conf", "sites/asia/tokyo/bird.conf"]),
+    );
+    expect(selectAutoDetectedEntry(result)).toBeNull();
   });
 });

--- a/packages/@birdcc/core/test/eligibility-resilience.test.ts
+++ b/packages/@birdcc/core/test/eligibility-resilience.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   parseBirdConfig: vi.fn(),
@@ -11,6 +11,10 @@ vi.mock("@birdcc/parser", () => ({
 import { evaluateBirdDocumentEligibility } from "../src/detection/eligibility.js";
 
 describe("BIRD document eligibility resilience", () => {
+  beforeEach(() => {
+    mocks.parseBirdConfig.mockReset();
+  });
+
   it("rejects an ordinary document when the parser fails", async () => {
     mocks.parseBirdConfig.mockRejectedValueOnce(new Error("parser failed"));
 
@@ -33,7 +37,7 @@ describe("BIRD document eligibility resilience", () => {
       "explicit-main",
     ],
   ])(
-    "preserves the %s escape hatch when the parser fails",
+    "uses the %s escape hatch without invoking the parser",
     async (_name, options, reason) => {
       mocks.parseBirdConfig.mockRejectedValueOnce(new Error("parser failed"));
 
@@ -44,6 +48,7 @@ describe("BIRD document eligibility resilience", () => {
         reason,
         declarationKinds: [],
       });
+      expect(mocks.parseBirdConfig).not.toHaveBeenCalled();
     },
   );
 });

--- a/packages/@birdcc/core/test/eligibility-resilience.test.ts
+++ b/packages/@birdcc/core/test/eligibility-resilience.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  parseBirdConfig: vi.fn(),
+}));
+
+vi.mock("@birdcc/parser", () => ({
+  parseBirdConfig: mocks.parseBirdConfig,
+}));
+
+import { evaluateBirdDocumentEligibility } from "../src/detection/eligibility.js";
+
+describe("BIRD document eligibility resilience", () => {
+  it("rejects an ordinary document when the parser fails", async () => {
+    mocks.parseBirdConfig.mockRejectedValueOnce(new Error("parser failed"));
+
+    await expect(
+      evaluateBirdDocumentEligibility("protocol device {}", {
+        filePath: "custom.conf",
+      }),
+    ).resolves.toEqual({
+      eligible: false,
+      reason: "no-evidence",
+      declarationKinds: [],
+    });
+  });
+
+  it.each([
+    ["canonical", { filePath: "bird.conf" }, "canonical-filename"],
+    [
+      "explicit main",
+      { filePath: "custom.conf", explicitMain: true },
+      "explicit-main",
+    ],
+  ])(
+    "preserves the %s escape hatch when the parser fails",
+    async (_name, options, reason) => {
+      mocks.parseBirdConfig.mockRejectedValueOnce(new Error("parser failed"));
+
+      await expect(
+        evaluateBirdDocumentEligibility("", options),
+      ).resolves.toEqual({
+        eligible: true,
+        reason,
+        declarationKinds: [],
+      });
+    },
+  );
+});

--- a/packages/@birdcc/core/test/eligibility.test.ts
+++ b/packages/@birdcc/core/test/eligibility.test.ts
@@ -74,32 +74,15 @@ describe("BIRD document eligibility", () => {
     });
   });
 
-  it("skips evidence parsing for oversized non-canonical documents", async () => {
+  it("keeps semantic eligibility independent of document size", async () => {
     const oversized = `protocol device {}\n${"# padding\n".repeat(120_000)}`;
     expect(oversized.length).toBeGreaterThan(1024 * 1024);
 
     await expect(
       evaluateBirdDocumentEligibility(oversized, { filePath: "custom.conf" }),
     ).resolves.toMatchObject({
-      eligible: false,
-      reason: "no-evidence",
-    });
-
-    // Trusted escape hatches are checked before the size limit and stay eligible.
-    await expect(
-      evaluateBirdDocumentEligibility(oversized, { filePath: "bird.conf" }),
-    ).resolves.toMatchObject({
       eligible: true,
-      reason: "canonical-filename",
-    });
-    await expect(
-      evaluateBirdDocumentEligibility(oversized, {
-        filePath: "custom.conf",
-        explicitMain: true,
-      }),
-    ).resolves.toMatchObject({
-      eligible: true,
-      reason: "explicit-main",
+      reason: "semantic-evidence",
     });
   });
 

--- a/packages/@birdcc/core/test/eligibility.test.ts
+++ b/packages/@birdcc/core/test/eligibility.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateBirdDocumentEligibility,
+  isCanonicalBirdConfigPath,
+} from "../src/detection/index.js";
+
+describe("BIRD document eligibility", () => {
+  it.each([
+    ["empty", ""],
+    ["comment", "# protocol device {}"],
+    ["string", 'message = "protocol device {}";'],
+    ["nginx", "events {}\nhttp { server { listen 80; } }"],
+    ["apache", "<VirtualHost *:80>\n  ServerName example.test\n</VirtualHost>"],
+    ["haproxy", "global\n  daemon\ndefaults\n  mode http"],
+    ["redis", "maxmemory 2gb\nsave 60 1"],
+    ["prometheus", "global:\n  scrape_interval: 15s"],
+    ["systemd", "[Service]\nExecStart=/usr/bin/example"],
+    [
+      "foreign protocol DSL",
+      'protocol http { endpoint = "https://example.test"; }',
+    ],
+  ])("rejects %s content without BIRD evidence", async (_name, content) => {
+    const result = await evaluateBirdDocumentEligibility(content, {
+      filePath: "custom.conf",
+    });
+
+    expect(result).toEqual({
+      eligible: false,
+      reason: "no-evidence",
+      declarationKinds: [],
+    });
+  });
+
+  it.each([
+    ["router id 192.0.2.1;", "router-id"],
+    ['include "parts/*.conf";', "include"],
+    ["define LOCAL_AS = 65001;", "define"],
+    ["ipv4 table master4;", "table"],
+    ["filter IMPORT { accept; }", "filter"],
+    ["function metric() { return 100; }", "function"],
+    ["template bgp EDGE {}", "template"],
+    ["protocol device {}", "protocol"],
+    ['timeformat log "%F %T";', "timeformat"],
+  ])("accepts parsed %s declarations", async (content, declarationKind) => {
+    const result = await evaluateBirdDocumentEligibility(content, {
+      filePath: "custom.conf",
+    });
+
+    expect(result.eligible).toBe(true);
+    expect(result.reason).toBe("semantic-evidence");
+    expect(result.declarationKinds).toContain(declarationKind);
+  });
+
+  it("keeps canonical and explicit-main escape hatches", async () => {
+    expect(isCanonicalBirdConfigPath("/etc/bird/bird3.conf")).toBe(true);
+    expect(isCanonicalBirdConfigPath("/tmp/.bird2.conf")).toBe(true);
+
+    await expect(
+      evaluateBirdDocumentEligibility("", { filePath: "bird6.conf" }),
+    ).resolves.toMatchObject({
+      eligible: true,
+      reason: "canonical-filename",
+    });
+    await expect(
+      evaluateBirdDocumentEligibility("", {
+        filePath: "custom.conf",
+        explicitMain: true,
+      }),
+    ).resolves.toMatchObject({
+      eligible: true,
+      reason: "explicit-main",
+    });
+  });
+});

--- a/packages/@birdcc/core/test/eligibility.test.ts
+++ b/packages/@birdcc/core/test/eligibility.test.ts
@@ -74,6 +74,35 @@ describe("BIRD document eligibility", () => {
     });
   });
 
+  it("skips evidence parsing for oversized non-canonical documents", async () => {
+    const oversized = `protocol device {}\n${"# padding\n".repeat(120_000)}`;
+    expect(oversized.length).toBeGreaterThan(1024 * 1024);
+
+    await expect(
+      evaluateBirdDocumentEligibility(oversized, { filePath: "custom.conf" }),
+    ).resolves.toMatchObject({
+      eligible: false,
+      reason: "no-evidence",
+    });
+
+    // Trusted escape hatches are checked before the size limit and stay eligible.
+    await expect(
+      evaluateBirdDocumentEligibility(oversized, { filePath: "bird.conf" }),
+    ).resolves.toMatchObject({
+      eligible: true,
+      reason: "canonical-filename",
+    });
+    await expect(
+      evaluateBirdDocumentEligibility(oversized, {
+        filePath: "custom.conf",
+        explicitMain: true,
+      }),
+    ).resolves.toMatchObject({
+      eligible: true,
+      reason: "explicit-main",
+    });
+  });
+
   it("ignores malformed protocol declarations without a protocol type", () => {
     const parsed = {
       program: {

--- a/packages/@birdcc/core/test/eligibility.test.ts
+++ b/packages/@birdcc/core/test/eligibility.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
+import type { ParsedBirdDocument } from "@birdcc/parser";
 import {
+  collectBirdDeclarationEvidence,
   evaluateBirdDocumentEligibility,
   isCanonicalBirdConfigPath,
 } from "../src/detection/index.js";
@@ -70,5 +72,15 @@ describe("BIRD document eligibility", () => {
       eligible: true,
       reason: "explicit-main",
     });
+  });
+
+  it("ignores malformed protocol declarations without a protocol type", () => {
+    const parsed = {
+      program: {
+        declarations: [{ kind: "protocol", statements: [] }],
+      },
+    } as unknown as ParsedBirdDocument;
+
+    expect(collectBirdDeclarationEvidence(parsed)).toEqual([]);
   });
 });

--- a/packages/@birdcc/core/test/include-graph.test.ts
+++ b/packages/@birdcc/core/test/include-graph.test.ts
@@ -1,0 +1,32 @@
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveIncludeGraph } from "../src/detection/include-graph.js";
+import type { ContentSignals } from "../src/detection/types.js";
+
+const createSignals = (includeStatements: string[]): ContentSignals => ({
+  hasGlobalRouterId: false,
+  hasProtocolRouterIdOnly: false,
+  hasProtocolDevice: false,
+  hasProtocolKernel: false,
+  hasLogDirective: false,
+  hasProtocolBlock: false,
+  hasDefine: false,
+  includeStatements,
+  commentedIncludes: [],
+});
+
+describe("include graph root boundary", () => {
+  it("rejects an include that resolves to the root parent itself", () => {
+    const graph = resolveIncludeGraph(
+      resolve("workspace"),
+      new Map([
+        ["bird.conf", createSignals([".."])],
+        ["..", createSignals([])],
+      ]),
+    );
+
+    expect(graph.edges.get("bird.conf")).toEqual([]);
+    expect(graph.missingBySource.get("bird.conf")).toBe(1);
+    expect(graph.includedByCount.get("..")).toBeUndefined();
+  });
+});

--- a/packages/@birdcc/lsp/src/document-eligibility.ts
+++ b/packages/@birdcc/lsp/src/document-eligibility.ts
@@ -9,13 +9,23 @@ export const evaluateLspDocumentEligibility = (
   text: string,
   documentUri: string,
   project: ProjectAnalysisOptions,
-): Promise<BirdDocumentEligibility> =>
-  evaluateBirdDocumentEligibility(text, {
-    filePath: documentUri.startsWith("file://")
-      ? fileURLToPath(documentUri)
-      : undefined,
+): Promise<BirdDocumentEligibility> => {
+  let filePath: string | undefined;
+  if (documentUri.startsWith("file://")) {
+    try {
+      filePath = fileURLToPath(documentUri);
+    } catch {
+      // A malformed file URI must not crash eligibility checks; fall back to
+      // undefined so evaluation proceeds without a filesystem-backed path.
+      filePath = undefined;
+    }
+  }
+
+  return evaluateBirdDocumentEligibility(text, {
+    filePath,
     explicitMain:
       project.mode === "main" &&
       project.configPath !== undefined &&
       project.entryUri === documentUri,
   });
+};

--- a/packages/@birdcc/lsp/src/document-eligibility.ts
+++ b/packages/@birdcc/lsp/src/document-eligibility.ts
@@ -1,0 +1,21 @@
+import { fileURLToPath } from "node:url";
+import {
+  evaluateBirdDocumentEligibility,
+  type BirdDocumentEligibility,
+} from "@birdcc/core";
+import type { ProjectAnalysisOptions } from "./project-config.js";
+
+export const evaluateLspDocumentEligibility = (
+  text: string,
+  documentUri: string,
+  project: ProjectAnalysisOptions,
+): Promise<BirdDocumentEligibility> =>
+  evaluateBirdDocumentEligibility(text, {
+    filePath: documentUri.startsWith("file://")
+      ? fileURLToPath(documentUri)
+      : undefined,
+    explicitMain:
+      project.mode === "main" &&
+      project.configPath !== undefined &&
+      project.entryUri === documentUri,
+  });

--- a/packages/@birdcc/lsp/src/index.ts
+++ b/packages/@birdcc/lsp/src/index.ts
@@ -21,6 +21,7 @@ export {
 export { createAsnInlayHints } from "./asn-inlay-hints.js";
 export { createAsnHover } from "./asn-hover.js";
 export { startLspServer, type LspServerOptions } from "./lsp-server.js";
+export { evaluateLspDocumentEligibility } from "./document-eligibility.js";
 export {
   toCanonicalKey,
   toLspRange,

--- a/packages/@birdcc/lsp/src/init/workspace-init.ts
+++ b/packages/@birdcc/lsp/src/init/workspace-init.ts
@@ -11,7 +11,11 @@
 
 import { resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { sniffProjectEntrypoints, type DetectionResult } from "@birdcc/core";
+import {
+  selectAutoDetectedEntry,
+  sniffProjectEntrypoints,
+  type DetectionResult,
+} from "@birdcc/core";
 import type { Connection } from "vscode-languageserver/node.js";
 import { showInfo, showWarning } from "../utils.js";
 
@@ -57,17 +61,18 @@ export const detectWorkspaceEntry = async (
   // Determine suggested entry and whether confirmation is needed
   let suggestedEntryUri: string | null = null;
   let needsConfirmation = false;
+  const selectedEntry = selectAutoDetectedEntry(result);
 
   switch (result.kind) {
     case "single": {
-      if (result.primary) {
-        suggestedEntryUri = toSuggestedEntryUri(result.primary.path);
+      if (selectedEntry) {
+        suggestedEntryUri = toSuggestedEntryUri(selectedEntry.path);
         connection.console.log(
-          `[init] Auto-detected entry: ${result.primary.path} (confidence: ${result.confidence}%)`,
+          `[init] Auto-detected entry: ${selectedEntry.path} (confidence: ${result.confidence}%)`,
         );
         showInfo(
           connection,
-          `Auto-detected BIRD entry: ${result.primary.path} (${result.confidence}% confidence).`,
+          `Auto-detected BIRD entry: ${selectedEntry.path} (${result.confidence}% confidence).`,
         );
       }
       break;
@@ -75,7 +80,6 @@ export const detectWorkspaceEntry = async (
 
     case "single-ambiguous": {
       if (result.primary) {
-        suggestedEntryUri = toSuggestedEntryUri(result.primary.path);
         needsConfirmation = true;
         showWarning(
           connection,
@@ -94,11 +98,11 @@ export const detectWorkspaceEntry = async (
     }
 
     case "monorepo-multi-role": {
-      if (result.primary) {
-        suggestedEntryUri = toSuggestedEntryUri(result.primary.path);
+      if (selectedEntry) {
+        suggestedEntryUri = toSuggestedEntryUri(selectedEntry.path);
         showInfo(
           connection,
-          `BIRD project with multiple roles detected. Entry: ${result.primary.path}. Run \`birdcc init --write\` for full configuration.`,
+          `BIRD project with multiple roles detected. Entry: ${selectedEntry.path}. Run \`birdcc init --write\` for full configuration.`,
         );
       }
       break;

--- a/packages/@birdcc/lsp/src/lsp-server.ts
+++ b/packages/@birdcc/lsp/src/lsp-server.ts
@@ -124,7 +124,10 @@ export const startLspServer = (options?: LspServerOptions): void => {
   const graphByUri = new Map<string, GraphCacheEntry>();
   const typeHintsByUri = new Map<string, TypeHintCacheEntry>();
   const eligibilityByUri = new Map<string, EligibilityCacheEntry>();
-  const pendingEligibilityByKey = new Map<string, Promise<boolean>>();
+  const pendingEligibilityByKey = new Map<
+    string,
+    { document: TextDocument; promise: Promise<boolean> }
+  >();
   const publishedUrisByEntry = new Map<string, Set<string>>();
   /** Dedup in-flight `getGraphForDocument` calls so concurrent requests share one analysis. */
   const pendingGraphByUri = new Map<string, Promise<GraphCacheEntry>>();
@@ -231,8 +234,8 @@ export const startLspServer = (options?: LspServerOptions): void => {
     const evaluationGeneration = projectConfigGeneration;
     const pendingKey = `${document.uri}@${document.version}@${evaluationGeneration}`;
     const pending = pendingEligibilityByKey.get(pendingKey);
-    if (pending) {
-      return pending;
+    if (pending?.document === document) {
+      return pending.promise;
     }
 
     const task = (async (): Promise<boolean> => {
@@ -245,7 +248,7 @@ export const startLspServer = (options?: LspServerOptions): void => {
       );
       if (
         evaluationGeneration === projectConfigGeneration &&
-        documents.get(document.uri)
+        documents.get(document.uri) === document
       ) {
         // Guard against out-of-order completions: only overwrite the cache when
         // this task evaluated a newer (or the same) document version. Skip the
@@ -267,11 +270,11 @@ export const startLspServer = (options?: LspServerOptions): void => {
       return eligibility.eligible;
     })();
 
-    pendingEligibilityByKey.set(pendingKey, task);
+    pendingEligibilityByKey.set(pendingKey, { document, promise: task });
     try {
       return await task;
     } finally {
-      if (pendingEligibilityByKey.get(pendingKey) === task) {
+      if (pendingEligibilityByKey.get(pendingKey)?.promise === task) {
         pendingEligibilityByKey.delete(pendingKey);
       }
     }

--- a/packages/@birdcc/lsp/src/lsp-server.ts
+++ b/packages/@birdcc/lsp/src/lsp-server.ts
@@ -244,11 +244,20 @@ export const startLspServer = (options?: LspServerOptions): void => {
         resolvedProject,
       );
       if (evaluationGeneration === projectConfigGeneration) {
-        eligibilityByUri.set(document.uri, {
-          version: document.version,
-          projectConfigGeneration: evaluationGeneration,
-          eligible: eligibility.eligible,
-        });
+        // Guard against out-of-order completions: only overwrite the cache when
+        // this task evaluated a newer (or the same) document version.
+        const currentCached = eligibilityByUri.get(document.uri);
+        if (
+          !currentCached ||
+          currentCached.projectConfigGeneration !== evaluationGeneration ||
+          currentCached.version < document.version
+        ) {
+          eligibilityByUri.set(document.uri, {
+            version: document.version,
+            projectConfigGeneration: evaluationGeneration,
+            eligible: eligibility.eligible,
+          });
+        }
       }
       return eligibility.eligible;
     })();

--- a/packages/@birdcc/lsp/src/lsp-server.ts
+++ b/packages/@birdcc/lsp/src/lsp-server.ts
@@ -80,6 +80,7 @@ interface TypeHintCacheEntry {
 
 interface EligibilityCacheEntry {
   version: number;
+  projectConfigGeneration: number;
   eligible: boolean;
 }
 
@@ -130,6 +131,7 @@ export const startLspServer = (options?: LspServerOptions): void => {
   const announcedInfoNotifications = new Set<string>();
   let workspaceRootUris: string[] = [];
   let supportsDynamicFileWatching = false;
+  let projectConfigGeneration = 0;
   let noConfigTipAnnounced = false;
   let hasShutdownBeenRequested = false;
   const typeHintMaxBytes = TYPE_HINT_MAX_FILE_SIZE_BYTES;
@@ -218,10 +220,14 @@ export const startLspServer = (options?: LspServerOptions): void => {
     project?: ProjectAnalysisOptions,
   ): Promise<boolean> => {
     const cached = eligibilityByUri.get(document.uri);
-    if (cached?.version === document.version) {
+    if (
+      cached?.version === document.version &&
+      cached.projectConfigGeneration === projectConfigGeneration
+    ) {
       return cached.eligible;
     }
 
+    const evaluationGeneration = projectConfigGeneration;
     const resolvedProject =
       project ?? (await resolveProjectForDocument(document));
     const eligibility = await evaluateLspDocumentEligibility(
@@ -229,10 +235,13 @@ export const startLspServer = (options?: LspServerOptions): void => {
       document.uri,
       resolvedProject,
     );
-    eligibilityByUri.set(document.uri, {
-      version: document.version,
-      eligible: eligibility.eligible,
-    });
+    if (evaluationGeneration === projectConfigGeneration) {
+      eligibilityByUri.set(document.uri, {
+        version: document.version,
+        projectConfigGeneration: evaluationGeneration,
+        eligible: eligibility.eligible,
+      });
+    }
     return eligibility.eligible;
   };
 
@@ -240,30 +249,40 @@ export const startLspServer = (options?: LspServerOptions): void => {
     document: TextDocument,
   ): Promise<GraphCacheEntry> => {
     const lintResult = await lintBirdConfig("", { uri: document.uri });
-    const graph: GraphCacheEntry = {
+    return {
       entryUri: document.uri,
       visitedUris: new Set([document.uri]),
       symbolTable: lintResult.core.symbolTable,
       byUri: { [document.uri]: lintResult },
     };
-
-    clearEntryTracking(document.uri);
-    parsedByUri.delete(document.uri);
-    typeHintsByUri.delete(document.uri);
-    graphByUri.set(document.uri, graph);
-    return graph;
   };
 
   const analyzeDocument = async (
     document: TextDocument,
     options: { publishRelatedDiagnostics: boolean },
   ): Promise<{ entryDiagnostics: Diagnostic[]; graph: GraphCacheEntry }> => {
+    const analysisGeneration = projectConfigGeneration;
     const project = await resolveProjectForDocument(document);
+    if (analysisGeneration !== projectConfigGeneration) {
+      return analyzeDocument(document, options);
+    }
 
-    if (!(await isDocumentEligible(document, project))) {
+    const eligible = await isDocumentEligible(document, project);
+    if (analysisGeneration !== projectConfigGeneration) {
+      return analyzeDocument(document, options);
+    }
+    if (!eligible) {
+      const graph = await createEmptyGraph(document);
+      if (analysisGeneration !== projectConfigGeneration) {
+        return analyzeDocument(document, options);
+      }
+      clearEntryTracking(document.uri);
+      parsedByUri.delete(document.uri);
+      typeHintsByUri.delete(document.uri);
+      graphByUri.set(document.uri, graph);
       return {
         entryDiagnostics: [],
-        graph: await createEmptyGraph(document),
+        graph,
       };
     }
 
@@ -298,6 +317,9 @@ export const startLspServer = (options?: LspServerOptions): void => {
       const lintResult = await lintBirdConfig(document.getText(), {
         uri: document.uri,
       });
+      if (analysisGeneration !== projectConfigGeneration) {
+        return analyzeDocument(document, options);
+      }
       const graph: GraphCacheEntry = {
         entryUri: document.uri,
         visitedUris: new Set([document.uri]),
@@ -338,6 +360,9 @@ export const startLspServer = (options?: LspServerOptions): void => {
       lintGraph.byUri[document.uri] = await lintBirdConfig(document.getText(), {
         uri: document.uri,
       });
+    }
+    if (analysisGeneration !== projectConfigGeneration) {
+      return analyzeDocument(document, options);
     }
     const visitedUris = new Set(
       crossFile.visitedUris.length > 0
@@ -421,7 +446,9 @@ export const startLspServer = (options?: LspServerOptions): void => {
     try {
       return await promise;
     } finally {
-      pendingGraphByUri.delete(document.uri);
+      if (pendingGraphByUri.get(document.uri) === promise) {
+        pendingGraphByUri.delete(document.uri);
+      }
     }
   };
 
@@ -534,6 +561,7 @@ export const startLspServer = (options?: LspServerOptions): void => {
       return;
     }
 
+    projectConfigGeneration += 1;
     eligibilityByUri.clear();
     graphByUri.clear();
     pendingGraphByUri.clear();

--- a/packages/@birdcc/lsp/src/lsp-server.ts
+++ b/packages/@birdcc/lsp/src/lsp-server.ts
@@ -243,9 +243,14 @@ export const startLspServer = (options?: LspServerOptions): void => {
         document.uri,
         resolvedProject,
       );
-      if (evaluationGeneration === projectConfigGeneration) {
+      if (
+        evaluationGeneration === projectConfigGeneration &&
+        documents.get(document.uri)
+      ) {
         // Guard against out-of-order completions: only overwrite the cache when
-        // this task evaluated a newer (or the same) document version.
+        // this task evaluated a newer (or the same) document version. Skip the
+        // write entirely if the document was closed while this task was pending,
+        // so a resolved promise can't resurrect a deleted cache entry.
         const currentCached = eligibilityByUri.get(document.uri);
         if (
           !currentCached ||

--- a/packages/@birdcc/lsp/src/lsp-server.ts
+++ b/packages/@birdcc/lsp/src/lsp-server.ts
@@ -11,6 +11,7 @@ import {
 } from "@birdcc/core";
 import {
   createConnection,
+  DidChangeWatchedFilesNotification,
   type Diagnostic,
   type InlayHint,
   type InitializeResult,
@@ -128,6 +129,7 @@ export const startLspServer = (options?: LspServerOptions): void => {
   const announcedProjectConfigs = new Set<string>();
   const announcedInfoNotifications = new Set<string>();
   let workspaceRootUris: string[] = [];
+  let supportsDynamicFileWatching = false;
   let noConfigTipAnnounced = false;
   let hasShutdownBeenRequested = false;
   const typeHintMaxBytes = TYPE_HINT_MAX_FILE_SIZE_BYTES;
@@ -424,6 +426,9 @@ export const startLspServer = (options?: LspServerOptions): void => {
   };
 
   connection.onInitialize((params): InitializeResult => {
+    supportsDynamicFileWatching = Boolean(
+      params.capabilities.workspace?.didChangeWatchedFiles?.dynamicRegistration,
+    );
     workspaceRootUris =
       params.workspaceFolders
         ?.map((folder) => folder.uri)
@@ -454,6 +459,23 @@ export const startLspServer = (options?: LspServerOptions): void => {
   });
 
   connection.onInitialized(() => {
+    if (supportsDynamicFileWatching) {
+      void connection.client
+        .register(DidChangeWatchedFilesNotification.type, {
+          watchers: [
+            { globPattern: "**/bird.config.json" },
+            { globPattern: "**/birdcc.config.json" },
+          ],
+        })
+        .catch((error) => {
+          connection.console.log(
+            `[project] failed to watch configuration files: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        });
+    }
+
     void (async () => {
       for (const workspaceRootUri of workspaceRootUris) {
         if (hasShutdownBeenRequested) {
@@ -496,6 +518,34 @@ export const startLspServer = (options?: LspServerOptions): void => {
     publish: ({ uri, version, diagnostics }) => {
       publishDiagnostics(connection, uri, diagnostics, version);
     },
+  });
+
+  connection.onDidChangeWatchedFiles((params) => {
+    const projectConfigChanged = params.changes.some((change) => {
+      try {
+        return PROJECT_CONFIG_FILE_NAMES.includes(
+          basename(fileURLToPath(change.uri)),
+        );
+      } catch {
+        return false;
+      }
+    });
+    if (!projectConfigChanged) {
+      return;
+    }
+
+    eligibilityByUri.clear();
+    graphByUri.clear();
+    pendingGraphByUri.clear();
+    for (const publishedUris of publishedUrisByEntry.values()) {
+      clearDiagnosticsMany(connection, publishedUris);
+    }
+    publishedUrisByEntry.clear();
+    announcedProjectConfigs.clear();
+    noConfigTipAnnounced = false;
+    for (const document of documents.all()) {
+      scheduler.schedule(document);
+    }
   });
 
   documents.onDidOpen((event) => {

--- a/packages/@birdcc/lsp/src/lsp-server.ts
+++ b/packages/@birdcc/lsp/src/lsp-server.ts
@@ -38,8 +38,12 @@ import { createAsnInlayHints } from "./asn-inlay-hints.js";
 import { createTypeHintInlayHints } from "./type-hint-inlay.js";
 import { createAsnHover } from "./asn-hover.js";
 import { detectWorkspaceEntry } from "./init/workspace-init.js";
-import { resolveProjectAnalysisOptions } from "./project-config.js";
+import {
+  resolveProjectAnalysisOptions,
+  type ProjectAnalysisOptions,
+} from "./project-config.js";
 import { createReferenceLocations } from "./references.js";
+import { evaluateLspDocumentEligibility } from "./document-eligibility.js";
 import {
   clearDiagnostics,
   clearDiagnosticsMany,
@@ -71,6 +75,11 @@ interface GraphCacheEntry {
 interface TypeHintCacheEntry {
   version: number;
   hints: readonly FunctionReturnHint[];
+}
+
+interface EligibilityCacheEntry {
+  version: number;
+  eligible: boolean;
 }
 
 const warmupParserRuntime = async (): Promise<void> => {
@@ -112,6 +121,7 @@ export const startLspServer = (options?: LspServerOptions): void => {
   const parsedByUri = new Map<string, ParsedCacheEntry>();
   const graphByUri = new Map<string, GraphCacheEntry>();
   const typeHintsByUri = new Map<string, TypeHintCacheEntry>();
+  const eligibilityByUri = new Map<string, EligibilityCacheEntry>();
   const publishedUrisByEntry = new Map<string, Set<string>>();
   /** Dedup in-flight `getGraphForDocument` calls so concurrent requests share one analysis. */
   const pendingGraphByUri = new Map<string, Promise<GraphCacheEntry>>();
@@ -189,11 +199,10 @@ export const startLspServer = (options?: LspServerOptions): void => {
     }
   };
 
-  const analyzeDocument = async (
+  const resolveProjectForDocument = (
     document: TextDocument,
-    options: { publishRelatedDiagnostics: boolean },
-  ): Promise<{ entryDiagnostics: Diagnostic[]; graph: GraphCacheEntry }> => {
-    const project = await resolveProjectAnalysisOptions({
+  ): Promise<ProjectAnalysisOptions> =>
+    resolveProjectAnalysisOptions({
       documentUri: document.uri,
       workspaceRootUris,
       defaults: {
@@ -201,6 +210,60 @@ export const startLspServer = (options?: LspServerOptions): void => {
         maxFiles: INCLUDE_MAX_FILES,
       },
     });
+
+  const isDocumentEligible = async (
+    document: TextDocument,
+    project?: ProjectAnalysisOptions,
+  ): Promise<boolean> => {
+    const cached = eligibilityByUri.get(document.uri);
+    if (cached?.version === document.version) {
+      return cached.eligible;
+    }
+
+    const resolvedProject =
+      project ?? (await resolveProjectForDocument(document));
+    const eligibility = await evaluateLspDocumentEligibility(
+      document.getText(),
+      document.uri,
+      resolvedProject,
+    );
+    eligibilityByUri.set(document.uri, {
+      version: document.version,
+      eligible: eligibility.eligible,
+    });
+    return eligibility.eligible;
+  };
+
+  const createEmptyGraph = async (
+    document: TextDocument,
+  ): Promise<GraphCacheEntry> => {
+    const lintResult = await lintBirdConfig("", { uri: document.uri });
+    const graph: GraphCacheEntry = {
+      entryUri: document.uri,
+      visitedUris: new Set([document.uri]),
+      symbolTable: lintResult.core.symbolTable,
+      byUri: { [document.uri]: lintResult },
+    };
+
+    clearEntryTracking(document.uri);
+    parsedByUri.delete(document.uri);
+    typeHintsByUri.delete(document.uri);
+    graphByUri.set(document.uri, graph);
+    return graph;
+  };
+
+  const analyzeDocument = async (
+    document: TextDocument,
+    options: { publishRelatedDiagnostics: boolean },
+  ): Promise<{ entryDiagnostics: Diagnostic[]; graph: GraphCacheEntry }> => {
+    const project = await resolveProjectForDocument(document);
+
+    if (!(await isDocumentEligible(document, project))) {
+      return {
+        entryDiagnostics: [],
+        graph: await createEmptyGraph(document),
+      };
+    }
 
     if (
       project.configPath &&
@@ -447,6 +510,7 @@ export const startLspServer = (options?: LspServerOptions): void => {
     parsedByUri.delete(event.document.uri);
     clearEntryTracking(event.document.uri);
     typeHintsByUri.delete(event.document.uri);
+    eligibilityByUri.delete(event.document.uri);
     scheduler.close(event.document.uri);
   });
 
@@ -493,6 +557,9 @@ export const startLspServer = (options?: LspServerOptions): void => {
 
   connection.onDocumentSymbol(async (params) =>
     withDocument(documents, params.textDocument.uri, [], async (document) => {
+      if (!(await isDocumentEligible(document))) {
+        return [];
+      }
       const parsed = await getParsedDocument(document);
       return createDocumentSymbolsFromParsed(parsed);
     }),
@@ -500,6 +567,9 @@ export const startLspServer = (options?: LspServerOptions): void => {
 
   connection.onHover(async (params) =>
     withDocument(documents, params.textDocument.uri, null, async (document) => {
+      if (!(await isDocumentEligible(document))) {
+        return null;
+      }
       // Try ASN hover first (more specific)
       if (asnIntel.available) {
         const lineText = getLineText(document, params.position.line);
@@ -514,6 +584,9 @@ export const startLspServer = (options?: LspServerOptions): void => {
 
   connection.onDefinition(async (params) =>
     withDocument(documents, params.textDocument.uri, [], async (document) => {
+      if (!(await isDocumentEligible(document))) {
+        return [];
+      }
       try {
         const graph = await getGraphForDocument(document);
         return createDefinitionLocations(
@@ -530,6 +603,9 @@ export const startLspServer = (options?: LspServerOptions): void => {
 
   connection.onReferences(async (params) =>
     withDocument(documents, params.textDocument.uri, [], async (document) => {
+      if (!(await isDocumentEligible(document))) {
+        return [];
+      }
       try {
         const graph = await getGraphForDocument(document);
         return createReferenceLocations(
@@ -546,6 +622,9 @@ export const startLspServer = (options?: LspServerOptions): void => {
 
   connection.onCompletion(async (params) =>
     withDocument(documents, params.textDocument.uri, [], async (document) => {
+      if (!(await isDocumentEligible(document))) {
+        return [];
+      }
       const parsed = await getParsedDocument(document);
       const linePrefix = document.getText({
         start: { line: params.position.line, character: 0 },
@@ -575,6 +654,9 @@ export const startLspServer = (options?: LspServerOptions): void => {
 
   connection.onDocumentFormatting(async (params) =>
     withDocument(documents, params.textDocument.uri, [], async (document) => {
+      if (!(await isDocumentEligible(document))) {
+        return [];
+      }
       try {
         const text = document.getText();
         const result = await formatBirdConfig(text);
@@ -611,6 +693,9 @@ export const startLspServer = (options?: LspServerOptions): void => {
       params.textDocument.uri,
       [],
       async (document): Promise<InlayHint[]> => {
+        if (!(await isDocumentEligible(document))) {
+          return [];
+        }
         const text = document.getText();
         const results: InlayHint[] = [];
 

--- a/packages/@birdcc/lsp/src/lsp-server.ts
+++ b/packages/@birdcc/lsp/src/lsp-server.ts
@@ -124,6 +124,7 @@ export const startLspServer = (options?: LspServerOptions): void => {
   const graphByUri = new Map<string, GraphCacheEntry>();
   const typeHintsByUri = new Map<string, TypeHintCacheEntry>();
   const eligibilityByUri = new Map<string, EligibilityCacheEntry>();
+  const pendingEligibilityByKey = new Map<string, Promise<boolean>>();
   const publishedUrisByEntry = new Map<string, Set<string>>();
   /** Dedup in-flight `getGraphForDocument` calls so concurrent requests share one analysis. */
   const pendingGraphByUri = new Map<string, Promise<GraphCacheEntry>>();
@@ -228,21 +229,38 @@ export const startLspServer = (options?: LspServerOptions): void => {
     }
 
     const evaluationGeneration = projectConfigGeneration;
-    const resolvedProject =
-      project ?? (await resolveProjectForDocument(document));
-    const eligibility = await evaluateLspDocumentEligibility(
-      document.getText(),
-      document.uri,
-      resolvedProject,
-    );
-    if (evaluationGeneration === projectConfigGeneration) {
-      eligibilityByUri.set(document.uri, {
-        version: document.version,
-        projectConfigGeneration: evaluationGeneration,
-        eligible: eligibility.eligible,
-      });
+    const pendingKey = `${document.uri}@${document.version}@${evaluationGeneration}`;
+    const pending = pendingEligibilityByKey.get(pendingKey);
+    if (pending) {
+      return pending;
     }
-    return eligibility.eligible;
+
+    const task = (async (): Promise<boolean> => {
+      const resolvedProject =
+        project ?? (await resolveProjectForDocument(document));
+      const eligibility = await evaluateLspDocumentEligibility(
+        document.getText(),
+        document.uri,
+        resolvedProject,
+      );
+      if (evaluationGeneration === projectConfigGeneration) {
+        eligibilityByUri.set(document.uri, {
+          version: document.version,
+          projectConfigGeneration: evaluationGeneration,
+          eligible: eligibility.eligible,
+        });
+      }
+      return eligibility.eligible;
+    })();
+
+    pendingEligibilityByKey.set(pendingKey, task);
+    try {
+      return await task;
+    } finally {
+      if (pendingEligibilityByKey.get(pendingKey) === task) {
+        pendingEligibilityByKey.delete(pendingKey);
+      }
+    }
   };
 
   const createEmptyGraph = async (
@@ -563,6 +581,7 @@ export const startLspServer = (options?: LspServerOptions): void => {
 
     projectConfigGeneration += 1;
     eligibilityByUri.clear();
+    pendingEligibilityByKey.clear();
     graphByUri.clear();
     pendingGraphByUri.clear();
     for (const publishedUris of publishedUrisByEntry.values()) {

--- a/packages/@birdcc/lsp/src/project-config.ts
+++ b/packages/@birdcc/lsp/src/project-config.ts
@@ -1,7 +1,7 @@
 import { access, readFile } from "node:fs/promises";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { sniffProjectEntrypoints } from "@birdcc/core";
+import { selectAutoDetectedEntry, sniffProjectEntrypoints } from "@birdcc/core";
 
 const CONFIG_FILE_NAMES = ["bird.config.json", "birdcc.config.json"] as const;
 const DEFAULT_WORKSPACE_ENTRY_FILE = "bird.conf";
@@ -321,8 +321,9 @@ export const resolveProjectAnalysisOptions = async (
         maxDepth: 8,
         maxFiles: 20_000,
       });
-      if (detection.primary) {
-        const entryPath = resolve(workspaceRootPath, detection.primary.path);
+      const selectedEntry = selectAutoDetectedEntry(detection);
+      if (selectedEntry) {
+        const entryPath = resolve(workspaceRootPath, selectedEntry.path);
         return {
           entryUri: toFileUri(entryPath),
           workspaceRootUri: resolvedWorkspaceRootUri,

--- a/packages/@birdcc/lsp/test/document-eligibility.test.ts
+++ b/packages/@birdcc/lsp/test/document-eligibility.test.ts
@@ -1,0 +1,62 @@
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+import { evaluateLspDocumentEligibility } from "../src/document-eligibility.js";
+import type { ProjectAnalysisOptions } from "../src/project-config.js";
+
+const createProject = (
+  entryUri: string,
+  overrides: Partial<ProjectAnalysisOptions> = {},
+): ProjectAnalysisOptions => ({
+  entryUri,
+  includeSearchPathUris: [],
+  maxDepth: 16,
+  maxFiles: 256,
+  allowIncludeOutsideWorkspace: false,
+  crossFileEnabled: true,
+  mode: "document",
+  ...overrides,
+});
+
+describe("LSP document eligibility", () => {
+  it("rejects foreign documents in an unconfigured workspace", async () => {
+    const uri = pathToFileURL("/workspace/nginx.conf").toString();
+
+    await expect(
+      evaluateLspDocumentEligibility(
+        "events {}\nhttp { server { listen 80; } }",
+        uri,
+        createProject(uri),
+      ),
+    ).resolves.toMatchObject({ eligible: false, reason: "no-evidence" });
+  });
+
+  it("accepts canonical, explicit-main, and semantic BIRD documents", async () => {
+    const canonicalUri = pathToFileURL("/workspace/bird.conf").toString();
+    const explicitUri = pathToFileURL("/workspace/custom.conf").toString();
+
+    await expect(
+      evaluateLspDocumentEligibility(
+        "",
+        canonicalUri,
+        createProject(canonicalUri),
+      ),
+    ).resolves.toMatchObject({ eligible: true, reason: "canonical-filename" });
+    await expect(
+      evaluateLspDocumentEligibility(
+        "",
+        explicitUri,
+        createProject(explicitUri, {
+          mode: "main",
+          configPath: "/workspace/bird.config.json",
+        }),
+      ),
+    ).resolves.toMatchObject({ eligible: true, reason: "explicit-main" });
+    await expect(
+      evaluateLspDocumentEligibility(
+        "protocol device {}",
+        explicitUri,
+        createProject(explicitUri),
+      ),
+    ).resolves.toMatchObject({ eligible: true, reason: "semantic-evidence" });
+  });
+});

--- a/packages/@birdcc/lsp/test/document-eligibility.test.ts
+++ b/packages/@birdcc/lsp/test/document-eligibility.test.ts
@@ -59,4 +59,16 @@ describe("LSP document eligibility", () => {
       ),
     ).resolves.toMatchObject({ eligible: true, reason: "semantic-evidence" });
   });
+
+  it("falls back to semantic evidence for a malformed file URI", async () => {
+    const malformedUri = "file:///workspace/%ZZ.conf";
+
+    await expect(
+      evaluateLspDocumentEligibility(
+        "protocol device {}",
+        malformedUri,
+        createProject(malformedUri),
+      ),
+    ).resolves.toMatchObject({ eligible: true, reason: "semantic-evidence" });
+  });
 });

--- a/packages/@birdcc/lsp/test/project-config.test.ts
+++ b/packages/@birdcc/lsp/test/project-config.test.ts
@@ -151,4 +151,27 @@ describe("resolveProjectAnalysisOptions", () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it("falls back to the current document in a foreign-only workspace", async () => {
+    const root = await mkdtemp(join(tmpdir(), "birdcc-lsp-foreign-"));
+    try {
+      const documentPath = join(root, "nginx.conf");
+      await writeFile(
+        documentPath,
+        "events {}\nhttp { server { listen 80; } }\n",
+        "utf8",
+      );
+
+      const resolved = await resolveProjectAnalysisOptions({
+        documentUri: toUri(documentPath),
+        workspaceRootUris: [toUri(root)],
+        defaults: { maxDepth: 16, maxFiles: 256 },
+      });
+
+      expect(resolved.mode).toBe("document");
+      expect(resolved.entryUri).toBe(toUri(documentPath));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/@birdcc/lsp/test/workspace-init.test.ts
+++ b/packages/@birdcc/lsp/test/workspace-init.test.ts
@@ -37,4 +37,26 @@ describe("detectWorkspaceEntry", () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it("does not suggest a foreign configuration as a workspace entry", async () => {
+    const root = await mkdtemp(join(tmpdir(), "birdcc-lsp-init-foreign-"));
+    try {
+      await writeFile(
+        join(root, "nginx.conf"),
+        "events {}\nhttp { server { listen 80; } }\n",
+        "utf8",
+      );
+
+      const result = await detectWorkspaceEntry(
+        pathToFileURL(root).toString(),
+        createMockConnection(),
+      );
+
+      expect(result.detectionResult.kind).toBe("not-found");
+      expect(result.detectionResult.primary).toBeNull();
+      expect(result.suggestedEntryUri).toBeNull();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/@birdcc/vscode/README.md
+++ b/packages/@birdcc/vscode/README.md
@@ -58,6 +58,14 @@
 - File extensions: `.conf`, `.bird`, `.bird2`, `.bird3`, `.bird2.conf`, `.bird3.conf`
 - Filenames: `bird.conf`, `bird2.conf`
 
+The broad `.conf` association is preserved for compatibility with existing
+workspaces and syntax highlighting. BIRD diagnostics, navigation, type hints,
+fallback validation, and formatting are enabled only when the document has
+parsed BIRD declarations, uses a canonical BIRD filename, or is selected by
+`bird.config.json.main`. Files such as `nginx.conf` and `apache.conf` therefore
+keep their current language association without being analyzed or rewritten as
+BIRD configuration.
+
 ---
 
 ## Installation
@@ -103,8 +111,8 @@ code --install-extension bird2-lsp-0.1.0-alpha.vsix
 
 ### Quick Start
 
-1. After installing the extension, open any `.conf` or `.bird` file
-2. The extension will automatically recognize BIRD2 configuration files
+1. After installing the extension, open a BIRD `.conf` or `.bird` file
+2. The extension will recognize parsed BIRD declarations and canonical filenames
 3. Enjoy intelligent suggestions, real-time diagnostics, and code formatting
 
 ### Validate Configuration
@@ -273,11 +281,12 @@ This project is licensed under the [GPL-3.0 License](https://github.com/bird-chi
 ## 🙏 Acknowledgements
 
 <!-- CI START -->
+
 We gratefully acknowledge these upstream repositories for the real-world BIRD configuration examples that help validate parsing, formatting, linting, and editor support in this project:
 
 - [`PoemaIX/IX-BIRD-RS-Generator`](https://github.com/PoemaIX/IX-BIRD-RS-Generator)
 - [`HuJK-Data/JKNET-BIRD`](https://github.com/HuJK-Data/JKNET-BIRD)
-- [`@LaunchPad-Network`](https://github.com/LaunchPad-Network) *(private feed)*
+- [`@LaunchPad-Network`](https://github.com/LaunchPad-Network) _(private feed)_
 - [`186526/net186-config`](https://github.com/186526/net186-config)
 - [`SunyzNET/bird-config`](https://github.com/SunyzNET/bird-config)
 - [`tianshome/bird-configs-output`](https://github.com/tianshome/bird-configs-output)

--- a/packages/@birdcc/vscode/README.md
+++ b/packages/@birdcc/vscode/README.md
@@ -281,12 +281,11 @@ This project is licensed under the [GPL-3.0 License](https://github.com/bird-chi
 ## 🙏 Acknowledgements
 
 <!-- CI START -->
-
 We gratefully acknowledge these upstream repositories for the real-world BIRD configuration examples that help validate parsing, formatting, linting, and editor support in this project:
 
 - [`PoemaIX/IX-BIRD-RS-Generator`](https://github.com/PoemaIX/IX-BIRD-RS-Generator)
 - [`HuJK-Data/JKNET-BIRD`](https://github.com/HuJK-Data/JKNET-BIRD)
-- [`@LaunchPad-Network`](https://github.com/LaunchPad-Network) _(private feed)_
+- [`@LaunchPad-Network`](https://github.com/LaunchPad-Network) *(private feed)*
 - [`186526/net186-config`](https://github.com/186526/net186-config)
 - [`SunyzNET/bird-config`](https://github.com/SunyzNET/bird-config)
 - [`tianshome/bird-configs-output`](https://github.com/tianshome/bird-configs-output)

--- a/packages/@birdcc/vscode/e2e/run.mjs
+++ b/packages/@birdcc/vscode/e2e/run.mjs
@@ -1,4 +1,6 @@
 import path from "node:path";
+import os from "node:os";
+import { mkdtemp, rm } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
 import { runTests } from "@vscode/test-electron";
@@ -10,12 +12,17 @@ const run = async () => {
   const extensionDevelopmentPath = path.resolve(__dirname, "..");
   const extensionTestsPath = path.resolve(__dirname, "suite", "index.cjs");
 
-  await runTests({
-    version: "stable",
-    extensionDevelopmentPath,
-    extensionTestsPath,
-    launchArgs: ["--disable-extensions"],
-  });
+  const userDataDir = await mkdtemp(path.join(os.tmpdir(), "birdcc-vscode-"));
+  try {
+    await runTests({
+      version: "stable",
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: ["--disable-extensions", `--user-data-dir=${userDataDir}`],
+    });
+  } finally {
+    await rm(userDataDir, { recursive: true, force: true });
+  }
 };
 
 run().catch((error) => {

--- a/packages/@birdcc/vscode/e2e/suite/index.cjs
+++ b/packages/@birdcc/vscode/e2e/suite/index.cjs
@@ -46,9 +46,13 @@ const resolveConfigurationTarget = (vscode) =>
     ? vscode.ConfigurationTarget.Workspace
     : vscode.ConfigurationTarget.Global;
 
-const openTempBirdDocument = async (vscode, content) => {
+const openTempBirdDocument = async (
+  vscode,
+  content,
+  fileName = "e2e.bird2.conf",
+) => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "bird2-lsp-e2e-"));
-  const filePath = path.join(tempDir, "e2e.bird2.conf");
+  const filePath = path.join(tempDir, fileName);
   await writeFile(filePath, content, "utf8");
 
   const document = await vscode.workspace.openTextDocument(
@@ -121,7 +125,11 @@ const testLanguageAndFormatting = async (vscode) => {
     "",
   ].join("\n");
 
-  const { document, cleanup } = await openTempBirdDocument(vscode, sample);
+  const { document, cleanup } = await openTempBirdDocument(
+    vscode,
+    sample,
+    "bird.conf",
+  );
   const config = vscode.workspace.getConfiguration("bird2-lsp");
   const target = resolveConfigurationTarget(vscode);
   const originalFormatterEngine = config.get("formatter.engine");
@@ -188,6 +196,52 @@ const testLanguageAndFormatting = async (vscode) => {
   }
 };
 
+const testForeignConfigurationGuard = async (vscode) => {
+  for (const [fileName, content] of [
+    ["nginx.conf", "events {}\nhttp { server { listen 80; } }\n"],
+    [
+      "apache.conf",
+      "<VirtualHost *:80>\nServerName example.test\n</VirtualHost>\n",
+    ],
+  ]) {
+    const { document, cleanup } = await openTempBirdDocument(
+      vscode,
+      content,
+      fileName,
+    );
+    try {
+      assert.equal(
+        document.languageId,
+        "bird2",
+        `${fileName} should keep the existing .conf language association`,
+      );
+      const edits = await vscode.commands.executeCommand(
+        "vscode.executeFormatDocumentProvider",
+        document.uri,
+        { insertSpaces: true, tabSize: 2 },
+      );
+      assert.ok(
+        edits === undefined || Array.isArray(edits),
+        "format provider should return no result or an edit list",
+      );
+      assert.equal(
+        edits?.length ?? 0,
+        0,
+        `${fileName} must not be formatted as BIRD`,
+      );
+
+      await wait(500);
+      assert.equal(
+        vscode.languages.getDiagnostics(document.uri).length,
+        0,
+        `${fileName} must not receive BIRD diagnostics`,
+      );
+    } finally {
+      await cleanup();
+    }
+  }
+};
+
 const testConfigurationCommands = async (vscode) => {
   const workspaceFolder = await ensureWorkspaceFolder(vscode);
   const config = vscode.workspace.getConfiguration("bird2-lsp");
@@ -231,6 +285,7 @@ async function run() {
 
   await testCommandRegistration(vscode);
   await testLanguageAndFormatting(vscode);
+  await testForeignConfigurationGuard(vscode);
   await testConfigurationCommands(vscode);
 }
 

--- a/packages/@birdcc/vscode/src/eligibility/gate.ts
+++ b/packages/@birdcc/vscode/src/eligibility/gate.ts
@@ -151,9 +151,14 @@ export const createBirdDocumentEligibilityGate =
             explicitMain,
           },
         );
-        if (taskGeneration === generation) {
+        if (
+          taskGeneration === generation &&
+          workspace.textDocuments.some((doc) => doc.uri.toString() === uri)
+        ) {
           // Guard against out-of-order completions: only overwrite the cache
           // when this task evaluated a newer (or the same) document version.
+          // Skip the write if the document was closed while this task was
+          // pending, so a resolved promise can't resurrect a deleted entry.
           const currentCached = cache.get(uri);
           if (!currentCached || currentCached.version < document.version) {
             cache.set(uri, {

--- a/packages/@birdcc/vscode/src/eligibility/gate.ts
+++ b/packages/@birdcc/vscode/src/eligibility/gate.ts
@@ -10,6 +10,16 @@ interface EligibilityCacheEntry {
   readonly eligible: boolean;
 }
 
+interface BirdConfigWithMain {
+  readonly main: string;
+}
+
+const isBirdConfigWithMain = (value: unknown): value is BirdConfigWithMain =>
+  typeof value === "object" &&
+  value !== null &&
+  "main" in value &&
+  typeof value.main === "string";
+
 export interface BirdDocumentEligibilityGate extends Disposable {
   isEligible: (document: TextDocument) => Promise<boolean>;
   clear: () => void;
@@ -36,13 +46,8 @@ const findExplicitMain = async (document: TextDocument): Promise<boolean> => {
     for (const fileName of CONFIG_FILE_NAMES) {
       try {
         const configPath = resolve(current, fileName);
-        const parsed = JSON.parse(await readFile(configPath, "utf8")) as {
-          main?: unknown;
-        };
-        if (
-          typeof parsed.main !== "string" ||
-          parsed.main.trim().length === 0
-        ) {
+        const parsed: unknown = JSON.parse(await readFile(configPath, "utf8"));
+        if (!isBirdConfigWithMain(parsed) || parsed.main.trim().length === 0) {
           continue;
         }
 

--- a/packages/@birdcc/vscode/src/eligibility/gate.ts
+++ b/packages/@birdcc/vscode/src/eligibility/gate.ts
@@ -69,9 +69,13 @@ const findExplicitMain = async (document: TextDocument): Promise<boolean> => {
 export const createBirdDocumentEligibilityGate =
   (): BirdDocumentEligibilityGate => {
     const cache = new Map<string, EligibilityCacheEntry>();
+    const explicitMainByUri = new Map<string, boolean>();
     const pending = new Map<string, Promise<boolean>>();
+    let generation = 0;
     const clear = (): void => {
+      generation += 1;
       cache.clear();
+      explicitMainByUri.clear();
       pending.clear();
     };
 
@@ -85,7 +89,9 @@ export const createBirdDocumentEligibilityGate =
       configWatcher.onDidDelete(clear),
       workspace.onDidChangeWorkspaceFolders(clear),
       workspace.onDidCloseTextDocument((document) => {
-        cache.delete(document.uri.toString());
+        const uri = document.uri.toString();
+        cache.delete(uri);
+        explicitMainByUri.delete(uri);
       }),
     ];
 
@@ -102,19 +108,29 @@ export const createBirdDocumentEligibilityGate =
         return pendingResult;
       }
 
+      const taskGeneration = generation;
       const task = (async (): Promise<boolean> => {
+        let explicitMain = explicitMainByUri.get(uri);
+        if (explicitMain === undefined) {
+          explicitMain = await findExplicitMain(document);
+          if (taskGeneration === generation) {
+            explicitMainByUri.set(uri, explicitMain);
+          }
+        }
         const eligibility = await evaluateBirdDocumentEligibility(
           document.getText(),
           {
             filePath:
               document.uri.scheme === "file" ? document.uri.fsPath : undefined,
-            explicitMain: await findExplicitMain(document),
+            explicitMain,
           },
         );
-        cache.set(uri, {
-          version: document.version,
-          eligible: eligibility.eligible,
-        });
+        if (taskGeneration === generation) {
+          cache.set(uri, {
+            version: document.version,
+            eligible: eligibility.eligible,
+          });
+        }
         return eligibility.eligible;
       })();
 

--- a/packages/@birdcc/vscode/src/eligibility/gate.ts
+++ b/packages/@birdcc/vscode/src/eligibility/gate.ts
@@ -143,7 +143,9 @@ export const createBirdDocumentEligibilityGate =
       try {
         return await task;
       } finally {
-        pending.delete(pendingKey);
+        if (pending.get(pendingKey) === task) {
+          pending.delete(pendingKey);
+        }
       }
     };
 

--- a/packages/@birdcc/vscode/src/eligibility/gate.ts
+++ b/packages/@birdcc/vscode/src/eligibility/gate.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { readFile, realpath } from "node:fs/promises";
 import { dirname, isAbsolute, normalize, resolve } from "node:path";
 import { evaluateBirdDocumentEligibility } from "@birdcc/core";
 import { workspace, type Disposable, type TextDocument } from "vscode";
@@ -25,9 +25,32 @@ export interface BirdDocumentEligibilityGate extends Disposable {
   clear: () => void;
 }
 
-const normalizeForComparison = (filePath: string): string => {
-  const normalized = normalize(resolve(filePath));
-  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+const normalizePath = (filePath: string): string =>
+  normalize(resolve(filePath));
+
+const pathsReferToSameLocation = async (
+  leftPath: string,
+  rightPath: string,
+): Promise<boolean> => {
+  const left = normalizePath(leftPath);
+  const right = normalizePath(rightPath);
+  if (left === right) {
+    return true;
+  }
+
+  if (process.platform !== "win32" && process.platform !== "darwin") {
+    return false;
+  }
+
+  try {
+    const [realLeft, realRight] = await Promise.all([
+      realpath(left),
+      realpath(right),
+    ]);
+    return normalizePath(realLeft) === normalizePath(realRight);
+  } catch {
+    return false;
+  }
 };
 
 const findExplicitMain = async (document: TextDocument): Promise<boolean> => {
@@ -35,11 +58,9 @@ const findExplicitMain = async (document: TextDocument): Promise<boolean> => {
     return false;
   }
 
-  const documentPath = normalizeForComparison(document.uri.fsPath);
+  const documentPath = normalizePath(document.uri.fsPath);
   const workspaceRoot = workspace.getWorkspaceFolder(document.uri)?.uri.fsPath;
-  const stopPath = workspaceRoot
-    ? normalizeForComparison(workspaceRoot)
-    : undefined;
+  const stopPath = workspaceRoot ? normalizePath(workspaceRoot) : undefined;
   let current = dirname(documentPath);
 
   while (true) {
@@ -54,13 +75,13 @@ const findExplicitMain = async (document: TextDocument): Promise<boolean> => {
         const mainPath = isAbsolute(parsed.main)
           ? parsed.main
           : resolve(current, parsed.main);
-        return normalizeForComparison(mainPath) === documentPath;
+        return pathsReferToSameLocation(mainPath, documentPath);
       } catch {
         // Missing or invalid project configuration does not authorize the file.
       }
     }
 
-    if (stopPath && normalizeForComparison(current) === stopPath) {
+    if (stopPath && (await pathsReferToSameLocation(current, stopPath))) {
       return false;
     }
     const parent = dirname(current);

--- a/packages/@birdcc/vscode/src/eligibility/gate.ts
+++ b/packages/@birdcc/vscode/src/eligibility/gate.ts
@@ -38,7 +38,13 @@ const pathsReferToSameLocation = async (
     return true;
   }
 
-  if (process.platform !== "win32" && process.platform !== "darwin") {
+  const isCaseInsensitive =
+    process.platform === "win32" || process.platform === "darwin";
+  if (isCaseInsensitive && left.toLowerCase() === right.toLowerCase()) {
+    return true;
+  }
+
+  if (!isCaseInsensitive) {
     return false;
   }
 

--- a/packages/@birdcc/vscode/src/eligibility/gate.ts
+++ b/packages/@birdcc/vscode/src/eligibility/gate.ts
@@ -131,10 +131,15 @@ export const createBirdDocumentEligibilityGate =
           },
         );
         if (taskGeneration === generation) {
-          cache.set(uri, {
-            version: document.version,
-            eligible: eligibility.eligible,
-          });
+          // Guard against out-of-order completions: only overwrite the cache
+          // when this task evaluated a newer (or the same) document version.
+          const currentCached = cache.get(uri);
+          if (!currentCached || currentCached.version < document.version) {
+            cache.set(uri, {
+              version: document.version,
+              eligible: eligibility.eligible,
+            });
+          }
         }
         return eligibility.eligible;
       })();

--- a/packages/@birdcc/vscode/src/eligibility/gate.ts
+++ b/packages/@birdcc/vscode/src/eligibility/gate.ts
@@ -75,7 +75,11 @@ const findExplicitMain = async (document: TextDocument): Promise<boolean> => {
         const mainPath = isAbsolute(parsed.main)
           ? parsed.main
           : resolve(current, parsed.main);
-        return pathsReferToSameLocation(mainPath, documentPath);
+        if (await pathsReferToSameLocation(mainPath, documentPath)) {
+          return true;
+        }
+        // A non-matching main does not disqualify the document: keep checking
+        // other config filenames and parent directories for an explicit match.
       } catch {
         // Missing or invalid project configuration does not authorize the file.
       }

--- a/packages/@birdcc/vscode/src/eligibility/gate.ts
+++ b/packages/@birdcc/vscode/src/eligibility/gate.ts
@@ -1,0 +1,139 @@
+import { readFile } from "node:fs/promises";
+import { dirname, isAbsolute, normalize, resolve } from "node:path";
+import { evaluateBirdDocumentEligibility } from "@birdcc/core";
+import { workspace, type Disposable, type TextDocument } from "vscode";
+
+const CONFIG_FILE_NAMES = ["bird.config.json", "birdcc.config.json"] as const;
+
+interface EligibilityCacheEntry {
+  readonly version: number;
+  readonly eligible: boolean;
+}
+
+export interface BirdDocumentEligibilityGate extends Disposable {
+  isEligible: (document: TextDocument) => Promise<boolean>;
+  clear: () => void;
+}
+
+const normalizeForComparison = (filePath: string): string => {
+  const normalized = normalize(resolve(filePath));
+  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+};
+
+const findExplicitMain = async (document: TextDocument): Promise<boolean> => {
+  if (document.uri.scheme !== "file") {
+    return false;
+  }
+
+  const documentPath = normalizeForComparison(document.uri.fsPath);
+  const workspaceRoot = workspace.getWorkspaceFolder(document.uri)?.uri.fsPath;
+  const stopPath = workspaceRoot
+    ? normalizeForComparison(workspaceRoot)
+    : undefined;
+  let current = dirname(documentPath);
+
+  while (true) {
+    for (const fileName of CONFIG_FILE_NAMES) {
+      try {
+        const configPath = resolve(current, fileName);
+        const parsed = JSON.parse(await readFile(configPath, "utf8")) as {
+          main?: unknown;
+        };
+        if (
+          typeof parsed.main !== "string" ||
+          parsed.main.trim().length === 0
+        ) {
+          continue;
+        }
+
+        const mainPath = isAbsolute(parsed.main)
+          ? parsed.main
+          : resolve(current, parsed.main);
+        return normalizeForComparison(mainPath) === documentPath;
+      } catch {
+        // Missing or invalid project configuration does not authorize the file.
+      }
+    }
+
+    if (stopPath && normalizeForComparison(current) === stopPath) {
+      return false;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return false;
+    }
+    current = parent;
+  }
+};
+
+export const createBirdDocumentEligibilityGate =
+  (): BirdDocumentEligibilityGate => {
+    const cache = new Map<string, EligibilityCacheEntry>();
+    const pending = new Map<string, Promise<boolean>>();
+    const clear = (): void => {
+      cache.clear();
+      pending.clear();
+    };
+
+    const configWatcher = workspace.createFileSystemWatcher(
+      "**/{bird.config.json,birdcc.config.json}",
+    );
+    const subscriptions: Disposable[] = [
+      configWatcher,
+      configWatcher.onDidCreate(clear),
+      configWatcher.onDidChange(clear),
+      configWatcher.onDidDelete(clear),
+      workspace.onDidChangeWorkspaceFolders(clear),
+      workspace.onDidCloseTextDocument((document) => {
+        cache.delete(document.uri.toString());
+      }),
+    ];
+
+    const isEligible = async (document: TextDocument): Promise<boolean> => {
+      const uri = document.uri.toString();
+      const cached = cache.get(uri);
+      if (cached?.version === document.version) {
+        return cached.eligible;
+      }
+
+      const pendingKey = `${uri}@${document.version}`;
+      const pendingResult = pending.get(pendingKey);
+      if (pendingResult) {
+        return pendingResult;
+      }
+
+      const task = (async (): Promise<boolean> => {
+        const eligibility = await evaluateBirdDocumentEligibility(
+          document.getText(),
+          {
+            filePath:
+              document.uri.scheme === "file" ? document.uri.fsPath : undefined,
+            explicitMain: await findExplicitMain(document),
+          },
+        );
+        cache.set(uri, {
+          version: document.version,
+          eligible: eligibility.eligible,
+        });
+        return eligibility.eligible;
+      })();
+
+      pending.set(pendingKey, task);
+      try {
+        return await task;
+      } finally {
+        pending.delete(pendingKey);
+      }
+    };
+
+    return {
+      isEligible,
+      clear,
+      dispose: () => {
+        for (const subscription of subscriptions) {
+          subscription.dispose();
+        }
+        clear();
+      },
+    };
+  };

--- a/packages/@birdcc/vscode/src/eligibility/gate.ts
+++ b/packages/@birdcc/vscode/src/eligibility/gate.ts
@@ -38,16 +38,6 @@ const pathsReferToSameLocation = async (
     return true;
   }
 
-  const isCaseInsensitive =
-    process.platform === "win32" || process.platform === "darwin";
-  if (isCaseInsensitive && left.toLowerCase() === right.toLowerCase()) {
-    return true;
-  }
-
-  if (!isCaseInsensitive) {
-    return false;
-  }
-
   try {
     const [realLeft, realRight] = await Promise.all([
       realpath(left),

--- a/packages/@birdcc/vscode/src/eligibility/gate.ts
+++ b/packages/@birdcc/vscode/src/eligibility/gate.ts
@@ -10,6 +10,11 @@ interface EligibilityCacheEntry {
   readonly eligible: boolean;
 }
 
+interface PendingEligibilityEntry {
+  readonly document: TextDocument;
+  readonly promise: Promise<boolean>;
+}
+
 interface BirdConfigWithMain {
   readonly main: string;
 }
@@ -96,7 +101,7 @@ export const createBirdDocumentEligibilityGate =
   (): BirdDocumentEligibilityGate => {
     const cache = new Map<string, EligibilityCacheEntry>();
     const explicitMainByUri = new Map<string, boolean>();
-    const pending = new Map<string, Promise<boolean>>();
+    const pending = new Map<string, PendingEligibilityEntry>();
     let generation = 0;
     const clear = (): void => {
       generation += 1;
@@ -123,15 +128,17 @@ export const createBirdDocumentEligibilityGate =
 
     const isEligible = async (document: TextDocument): Promise<boolean> => {
       const uri = document.uri.toString();
+      const documentVersion = document.version;
+      const documentText = document.getText();
       const cached = cache.get(uri);
-      if (cached?.version === document.version) {
+      if (cached?.version === documentVersion) {
         return cached.eligible;
       }
 
-      const pendingKey = `${uri}@${document.version}`;
-      const pendingResult = pending.get(pendingKey);
-      if (pendingResult) {
-        return pendingResult;
+      const pendingKey = `${uri}@${documentVersion}`;
+      const pendingEntry = pending.get(pendingKey);
+      if (pendingEntry?.document === document) {
+        return pendingEntry.promise;
       }
 
       const taskGeneration = generation;
@@ -139,12 +146,15 @@ export const createBirdDocumentEligibilityGate =
         let explicitMain = explicitMainByUri.get(uri);
         if (explicitMain === undefined) {
           explicitMain = await findExplicitMain(document);
-          if (taskGeneration === generation) {
+          if (
+            taskGeneration === generation &&
+            workspace.textDocuments.includes(document)
+          ) {
             explicitMainByUri.set(uri, explicitMain);
           }
         }
         const eligibility = await evaluateBirdDocumentEligibility(
-          document.getText(),
+          documentText,
           {
             filePath:
               document.uri.scheme === "file" ? document.uri.fsPath : undefined,
@@ -153,16 +163,17 @@ export const createBirdDocumentEligibilityGate =
         );
         if (
           taskGeneration === generation &&
-          workspace.textDocuments.some((doc) => doc.uri.toString() === uri)
+          workspace.textDocuments.includes(document) &&
+          document.version === documentVersion
         ) {
           // Guard against out-of-order completions: only overwrite the cache
           // when this task evaluated a newer (or the same) document version.
           // Skip the write if the document was closed while this task was
           // pending, so a resolved promise can't resurrect a deleted entry.
           const currentCached = cache.get(uri);
-          if (!currentCached || currentCached.version < document.version) {
+          if (!currentCached || currentCached.version < documentVersion) {
             cache.set(uri, {
-              version: document.version,
+              version: documentVersion,
               eligible: eligibility.eligible,
             });
           }
@@ -170,11 +181,11 @@ export const createBirdDocumentEligibilityGate =
         return eligibility.eligible;
       })();
 
-      pending.set(pendingKey, task);
+      pending.set(pendingKey, { document, promise: task });
       try {
         return await task;
       } finally {
-        if (pending.get(pendingKey) === task) {
+        if (pending.get(pendingKey)?.promise === task) {
           pending.delete(pendingKey);
         }
       }

--- a/packages/@birdcc/vscode/src/eligibility/index.ts
+++ b/packages/@birdcc/vscode/src/eligibility/index.ts
@@ -1,0 +1,4 @@
+export {
+  createBirdDocumentEligibilityGate,
+  type BirdDocumentEligibilityGate,
+} from "./gate.js";

--- a/packages/@birdcc/vscode/src/extension.ts
+++ b/packages/@birdcc/vscode/src/extension.ts
@@ -12,6 +12,7 @@ import {
   type FallbackValidator,
 } from "./fallback/index.js";
 import { createBirdFormattingProvider } from "./formatter/index.js";
+import { createBirdDocumentEligibilityGate } from "./eligibility/index.js";
 import { registerBirdKeywordHoverProvider } from "./hover/index.js";
 import { createBirdStatusBarManager } from "./status/index.js";
 import { registerBirdTypeHintProviders } from "./type-hints/index.js";
@@ -86,6 +87,7 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
   );
   void announceProjectConfigGuidance(outputChannel);
   const configurationManager = createConfigurationManager();
+  const eligibilityGate = createBirdDocumentEligibilityGate();
   const statusBarManager = createBirdStatusBarManager();
   let lifecycleState: ClientLifecycleState = "idle";
   const refreshStatus = (): void => {
@@ -108,6 +110,7 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
   const formattingProvider = createBirdFormattingProvider(
     () => runtimeState.configuration,
     outputChannel,
+    eligibilityGate.isEligible,
   );
   let workspaceTrustWarningShown = false;
   const createOrGetFallbackValidator = (): FallbackValidator => {
@@ -115,6 +118,7 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
       fallbackValidator = createFallbackValidator(
         () => runtimeState.configuration,
         outputChannel,
+        eligibilityGate.isEligible,
       );
       fallbackValidator.activate();
     }
@@ -178,6 +182,7 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
     const oneShotValidator = createFallbackValidator(
       () => runtimeState.configuration,
       outputChannel,
+      eligibilityGate.isEligible,
     );
     try {
       await oneShotValidator.validateActiveEditor();
@@ -229,12 +234,14 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
   context.subscriptions.push(
     registerBirdKeywordHoverProvider({
       isLspActive: () => lifecycleState === "running",
+      isDocumentEligible: eligibilityGate.isEligible,
     }),
   );
   context.subscriptions.push(
     ...registerBirdTypeHintProviders({
       getConfiguration: () => runtimeState.configuration,
       outputChannel,
+      isDocumentEligible: eligibilityGate.isEligible,
     }),
   );
   context.subscriptions.push(
@@ -252,6 +259,7 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
       outputChannel.appendLine("[bird2-lsp] disposing extension");
       statusBarManager.dispose();
       configurationManager.dispose();
+      eligibilityGate.dispose();
       disposeFallbackValidator();
       deactivateTask = lifecycle.dispose();
     },

--- a/packages/@birdcc/vscode/src/fallback/validator.ts
+++ b/packages/@birdcc/vscode/src/fallback/validator.ts
@@ -138,6 +138,8 @@ const checkFilePermission = async (
 export const createFallbackValidator = (
   getConfiguration: () => ExtensionConfiguration,
   outputChannel: OutputChannel,
+  isDocumentEligible: (document: TextDocument) => Promise<boolean> = async () =>
+    true,
 ): FallbackValidator => {
   const diagnosticCollection =
     languages.createDiagnosticCollection("bird2-fallback");
@@ -209,6 +211,12 @@ export const createFallbackValidator = (
     }
 
     if (!isBirdDocument(document)) {
+      return;
+    }
+    if (!(await isDocumentEligible(document))) {
+      if (isLatestValidationTicket(uri, ticket)) {
+        clearDocumentDiagnostics(document);
+      }
       return;
     }
 

--- a/packages/@birdcc/vscode/src/formatter/provider.ts
+++ b/packages/@birdcc/vscode/src/formatter/provider.ts
@@ -29,6 +29,8 @@ const getFormatterModule = (): Promise<typeof import("@birdcc/formatter")> => {
 export const createBirdFormattingProvider = (
   getConfiguration: () => ExtensionConfiguration,
   outputChannel: OutputChannel,
+  isDocumentEligible: (document: TextDocument) => Promise<boolean> = async () =>
+    true,
 ): DocumentFormattingEditProvider & DocumentRangeFormattingEditProvider => {
   const warningCache = new Set<string>();
 
@@ -52,6 +54,9 @@ export const createBirdFormattingProvider = (
   return {
     provideDocumentFormattingEdits: async (document) => {
       if (document.languageId !== LANGUAGE_ID) {
+        return [];
+      }
+      if (!(await isDocumentEligible(document))) {
         return [];
       }
 
@@ -88,6 +93,9 @@ export const createBirdFormattingProvider = (
     },
     provideDocumentRangeFormattingEdits: async (document, range) => {
       if (document.languageId !== LANGUAGE_ID) {
+        return [];
+      }
+      if (!(await isDocumentEligible(document))) {
         return [];
       }
 

--- a/packages/@birdcc/vscode/src/hover/provider.ts
+++ b/packages/@birdcc/vscode/src/hover/provider.ts
@@ -5,6 +5,7 @@ import {
   Range,
   languages,
   type Disposable,
+  type TextDocument,
 } from "vscode";
 
 import { BIRD_DOCUMENT_SELECTOR, LANGUAGE_ID } from "../constants.js";
@@ -14,6 +15,7 @@ import type { ResolvedHoverTopic } from "./docs.js";
 export interface HoverProviderOptions {
   /** Return `true` when the LSP client is handling hover requests. */
   readonly isLspActive?: () => boolean;
+  readonly isDocumentEligible?: (document: TextDocument) => Promise<boolean>;
 }
 
 const toRange = (
@@ -70,6 +72,12 @@ export const registerBirdKeywordHoverProvider = (
   languages.registerHoverProvider([...BIRD_DOCUMENT_SELECTOR], {
     provideHover: async (document, position) => {
       if (document.languageId !== LANGUAGE_ID) {
+        return null;
+      }
+      if (
+        options?.isDocumentEligible &&
+        !(await options.isDocumentEligible(document))
+      ) {
         return null;
       }
 

--- a/packages/@birdcc/vscode/src/index.ts
+++ b/packages/@birdcc/vscode/src/index.ts
@@ -52,6 +52,10 @@ export {
 } from "./fallback/index.js";
 export { createBirdFormattingProvider } from "./formatter/index.js";
 export {
+  createBirdDocumentEligibilityGate,
+  type BirdDocumentEligibilityGate,
+} from "./eligibility/index.js";
+export {
   registerBirdKeywordHoverProvider,
   resolveHoverContextPath,
   loadBirdHoverDocs,

--- a/packages/@birdcc/vscode/src/type-hints/provider.ts
+++ b/packages/@birdcc/vscode/src/type-hints/provider.ts
@@ -26,6 +26,7 @@ import { createTypeHintCache } from "./cache.js";
 export interface BirdTypeHintRegistrationContext {
   readonly getConfiguration: () => ExtensionConfiguration;
   readonly outputChannel: OutputChannel;
+  readonly isDocumentEligible?: (document: TextDocument) => Promise<boolean>;
 }
 
 interface CachedHintSnapshot {
@@ -74,6 +75,7 @@ const appendReturnDetails = (
 export const registerBirdTypeHintProviders = ({
   getConfiguration,
   outputChannel,
+  isDocumentEligible = async () => true,
 }: BirdTypeHintRegistrationContext): readonly Disposable[] => {
   const cache = createTypeHintCache<FunctionReturnHint>({
     maxEntries: TYPE_HINT_CACHE_MAX_ENTRIES,
@@ -127,6 +129,9 @@ export const registerBirdTypeHintProviders = ({
           !configuration.typeHintsHoverEnabled ||
           !isBirdDocument(document)
         ) {
+          return null;
+        }
+        if (!(await isDocumentEligible(document))) {
           return null;
         }
 
@@ -207,6 +212,9 @@ export const registerBirdTypeHintProviders = ({
           !configuration.typeHintsInlayEnabled ||
           !isBirdDocument(document)
         ) {
+          return [];
+        }
+        if (!(await isDocumentEligible(document))) {
           return [];
         }
 

--- a/packages/@birdcc/vscode/test/eligibility-gate.test.ts
+++ b/packages/@birdcc/vscode/test/eligibility-gate.test.ts
@@ -139,6 +139,22 @@ describe("VS Code BIRD document eligibility gate", () => {
     gate.dispose();
   });
 
+  it("does not authorize an unresolved case-only path match", async () => {
+    const gate = createBirdDocumentEligibilityGate();
+    const virtualDocumentPath = join(mocks.workspaceRoot, "Virtual.conf");
+    await writeFile(
+      join(mocks.workspaceRoot, "bird.config.json"),
+      JSON.stringify({ main: "virtual.conf" }),
+      "utf8",
+    );
+
+    await expect(
+      gate.isEligible(createDocument(virtualDocumentPath, "", 1)),
+    ).resolves.toBe(false);
+
+    gate.dispose();
+  });
+
   it("caches explicit-main lookup until project configuration is invalidated", async () => {
     const gate = createBirdDocumentEligibilityGate();
     const explicitPath = join(mocks.workspaceRoot, "custom.conf");

--- a/packages/@birdcc/vscode/test/eligibility-gate.test.ts
+++ b/packages/@birdcc/vscode/test/eligibility-gate.test.ts
@@ -6,6 +6,7 @@ import type { TextDocument } from "vscode";
 
 const mocks = vi.hoisted(() => ({
   workspaceRoot: "",
+  openDocuments: [] as { uri: { toString(): string } }[],
 }));
 
 const disposable = () => ({ dispose: vi.fn() });
@@ -23,6 +24,9 @@ vi.mock("vscode", () => ({
     }),
     onDidChangeWorkspaceFolders: () => disposable(),
     onDidCloseTextDocument: () => disposable(),
+    get textDocuments() {
+      return mocks.openDocuments;
+    },
   },
 }));
 
@@ -32,8 +36,8 @@ const createDocument = (
   filePath: string,
   text: string,
   version: number,
-): TextDocument =>
-  ({
+): TextDocument => {
+  const document = {
     uri: {
       scheme: "file",
       fsPath: filePath,
@@ -41,10 +45,16 @@ const createDocument = (
     },
     version,
     getText: () => text,
-  }) as unknown as TextDocument;
+  } as unknown as TextDocument;
+  // Register the document as open so the eligibility gate's "still open" guard
+  // (workspace.textDocuments) treats it like a live editor document.
+  mocks.openDocuments.push(document);
+  return document;
+};
 
 describe("VS Code BIRD document eligibility gate", () => {
   beforeEach(async () => {
+    mocks.openDocuments = [];
     mocks.workspaceRoot = await mkdtemp(join(tmpdir(), "birdcc-vscode-gate-"));
   });
 

--- a/packages/@birdcc/vscode/test/eligibility-gate.test.ts
+++ b/packages/@birdcc/vscode/test/eligibility-gate.test.ts
@@ -92,6 +92,27 @@ describe("VS Code BIRD document eligibility gate", () => {
     gate.dispose();
   });
 
+  it("continues searching after a non-matching project configuration", async () => {
+    const gate = createBirdDocumentEligibilityGate();
+    const explicitPath = join(mocks.workspaceRoot, "custom.conf");
+    await writeFile(
+      join(mocks.workspaceRoot, "bird.config.json"),
+      JSON.stringify({ main: "other.conf" }),
+      "utf8",
+    );
+    await writeFile(
+      join(mocks.workspaceRoot, "birdcc.config.json"),
+      JSON.stringify({ main: "custom.conf" }),
+      "utf8",
+    );
+
+    await expect(
+      gate.isEligible(createDocument(explicitPath, "", 1)),
+    ).resolves.toBe(true);
+
+    gate.dispose();
+  });
+
   it("matches explicit-main casing according to the host file system", async () => {
     const gate = createBirdDocumentEligibilityGate();
     const explicitPath = join(mocks.workspaceRoot, "Custom.conf");

--- a/packages/@birdcc/vscode/test/eligibility-gate.test.ts
+++ b/packages/@birdcc/vscode/test/eligibility-gate.test.ts
@@ -117,4 +117,23 @@ describe("VS Code BIRD document eligibility gate", () => {
 
     gate.dispose();
   });
+
+  it.each(["null", "[]", '"bird.conf"'])(
+    "ignores non-object project configuration %s",
+    async (configContent) => {
+      const gate = createBirdDocumentEligibilityGate();
+      const customPath = join(mocks.workspaceRoot, "custom.conf");
+      await writeFile(
+        join(mocks.workspaceRoot, "bird.config.json"),
+        configContent,
+        "utf8",
+      );
+
+      await expect(
+        gate.isEligible(createDocument(customPath, "", 1)),
+      ).resolves.toBe(false);
+
+      gate.dispose();
+    },
+  );
 });

--- a/packages/@birdcc/vscode/test/eligibility-gate.test.ts
+++ b/packages/@birdcc/vscode/test/eligibility-gate.test.ts
@@ -91,4 +91,30 @@ describe("VS Code BIRD document eligibility gate", () => {
 
     gate.dispose();
   });
+
+  it("caches explicit-main lookup until project configuration is invalidated", async () => {
+    const gate = createBirdDocumentEligibilityGate();
+    const explicitPath = join(mocks.workspaceRoot, "custom.conf");
+    const configPath = join(mocks.workspaceRoot, "bird.config.json");
+    await writeFile(
+      configPath,
+      JSON.stringify({ main: "custom.conf" }),
+      "utf8",
+    );
+
+    await expect(
+      gate.isEligible(createDocument(explicitPath, "", 1)),
+    ).resolves.toBe(true);
+    await writeFile(configPath, JSON.stringify({}), "utf8");
+    await expect(
+      gate.isEligible(createDocument(explicitPath, "", 2)),
+    ).resolves.toBe(true);
+
+    gate.clear();
+    await expect(
+      gate.isEligible(createDocument(explicitPath, "", 3)),
+    ).resolves.toBe(false);
+
+    gate.dispose();
+  });
 });

--- a/packages/@birdcc/vscode/test/eligibility-gate.test.ts
+++ b/packages/@birdcc/vscode/test/eligibility-gate.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -88,6 +88,32 @@ describe("VS Code BIRD document eligibility gate", () => {
     await expect(
       gate.isEligible(createDocument(explicitPath, "", 1)),
     ).resolves.toBe(true);
+
+    gate.dispose();
+  });
+
+  it("matches explicit-main casing according to the host file system", async () => {
+    const gate = createBirdDocumentEligibilityGate();
+    const explicitPath = join(mocks.workspaceRoot, "Custom.conf");
+    const caseVariantPath = join(mocks.workspaceRoot, "custom.conf");
+    await writeFile(explicitPath, "", "utf8");
+    await writeFile(
+      join(mocks.workspaceRoot, "bird.config.json"),
+      JSON.stringify({ main: "custom.conf" }),
+      "utf8",
+    );
+
+    const caseVariantExists = await realpath(caseVariantPath).then(
+      () => true,
+      () => false,
+    );
+    const shouldMatch =
+      (process.platform === "win32" || process.platform === "darwin") &&
+      caseVariantExists;
+
+    await expect(
+      gate.isEligible(createDocument(explicitPath, "", 1)),
+    ).resolves.toBe(shouldMatch);
 
     gate.dispose();
   });

--- a/packages/@birdcc/vscode/test/eligibility-gate.test.ts
+++ b/packages/@birdcc/vscode/test/eligibility-gate.test.ts
@@ -6,13 +6,19 @@ import type { TextDocument } from "vscode";
 
 const mocks = vi.hoisted(() => ({
   workspaceRoot: "",
-  openDocuments: [] as { uri: { toString(): string } }[],
+  textDocuments: [] as TextDocument[],
+  onDidCloseTextDocument: undefined as
+    | ((document: TextDocument) => void)
+    | undefined,
 }));
 
 const disposable = () => ({ dispose: vi.fn() });
 
 vi.mock("vscode", () => ({
   workspace: {
+    get textDocuments() {
+      return mocks.textDocuments;
+    },
     getWorkspaceFolder: () => ({
       uri: { fsPath: mocks.workspaceRoot },
     }),
@@ -23,9 +29,9 @@ vi.mock("vscode", () => ({
       onDidDelete: () => disposable(),
     }),
     onDidChangeWorkspaceFolders: () => disposable(),
-    onDidCloseTextDocument: () => disposable(),
-    get textDocuments() {
-      return mocks.openDocuments;
+    onDidCloseTextDocument: (listener: (document: TextDocument) => void) => {
+      mocks.onDidCloseTextDocument = listener;
+      return disposable();
     },
   },
 }));
@@ -36,8 +42,8 @@ const createDocument = (
   filePath: string,
   text: string,
   version: number,
-): TextDocument => {
-  const document = {
+): TextDocument =>
+  ({
     uri: {
       scheme: "file",
       fsPath: filePath,
@@ -45,20 +51,18 @@ const createDocument = (
     },
     version,
     getText: () => text,
-  } as unknown as TextDocument;
-  // Register the document as open so the eligibility gate's "still open" guard
-  // (workspace.textDocuments) treats it like a live editor document.
-  mocks.openDocuments.push(document);
-  return document;
-};
+  }) as unknown as TextDocument;
 
 describe("VS Code BIRD document eligibility gate", () => {
   beforeEach(async () => {
-    mocks.openDocuments = [];
     mocks.workspaceRoot = await mkdtemp(join(tmpdir(), "birdcc-vscode-gate-"));
+    mocks.textDocuments = [];
+    mocks.onDidCloseTextDocument = undefined;
   });
 
   afterEach(async () => {
+    mocks.textDocuments = [];
+    mocks.onDidCloseTextDocument = undefined;
     await rm(mocks.workspaceRoot, { recursive: true, force: true });
   });
 
@@ -175,18 +179,56 @@ describe("VS Code BIRD document eligibility gate", () => {
       "utf8",
     );
 
-    await expect(
-      gate.isEligible(createDocument(explicitPath, "", 1)),
-    ).resolves.toBe(true);
+    const firstDocument = createDocument(explicitPath, "", 1);
+    mocks.textDocuments = [firstDocument];
+    await expect(gate.isEligible(firstDocument)).resolves.toBe(true);
     await writeFile(configPath, JSON.stringify({}), "utf8");
-    await expect(
-      gate.isEligible(createDocument(explicitPath, "", 2)),
-    ).resolves.toBe(true);
+    const secondDocument = createDocument(explicitPath, "", 2);
+    mocks.textDocuments = [secondDocument];
+    await expect(gate.isEligible(secondDocument)).resolves.toBe(true);
 
     gate.clear();
-    await expect(
-      gate.isEligible(createDocument(explicitPath, "", 3)),
-    ).resolves.toBe(false);
+    const thirdDocument = createDocument(explicitPath, "", 3);
+    mocks.textDocuments = [thirdDocument];
+    await expect(gate.isEligible(thirdDocument)).resolves.toBe(false);
+
+    gate.dispose();
+  });
+
+  it("does not reuse a pending result for a reopened document instance", async () => {
+    const gate = createBirdDocumentEligibilityGate();
+    const filePath = join(mocks.workspaceRoot, "custom.conf");
+    const closedDocument = createDocument(filePath, "protocol device {}", 1);
+    mocks.textDocuments = [closedDocument];
+
+    const closedResult = gate.isEligible(closedDocument);
+    mocks.textDocuments = [];
+    mocks.onDidCloseTextDocument?.(closedDocument);
+
+    const reopenedDocument = createDocument(filePath, "events {}", 1);
+    mocks.textDocuments = [reopenedDocument];
+    const reopenedResult = gate.isEligible(reopenedDocument);
+
+    await expect(closedResult).resolves.toBe(true);
+    await expect(reopenedResult).resolves.toBe(false);
+
+    gate.dispose();
+  });
+
+  it("does not repopulate caches after a document closes", async () => {
+    const gate = createBirdDocumentEligibilityGate();
+    const filePath = join(mocks.workspaceRoot, "custom.conf");
+    const closedDocument = createDocument(filePath, "protocol device {}", 1);
+    mocks.textDocuments = [closedDocument];
+
+    const closedResult = gate.isEligible(closedDocument);
+    mocks.textDocuments = [];
+    mocks.onDidCloseTextDocument?.(closedDocument);
+    await expect(closedResult).resolves.toBe(true);
+
+    const reopenedDocument = createDocument(filePath, "events {}", 1);
+    mocks.textDocuments = [reopenedDocument];
+    await expect(gate.isEligible(reopenedDocument)).resolves.toBe(false);
 
     gate.dispose();
   });

--- a/packages/@birdcc/vscode/test/eligibility-gate.test.ts
+++ b/packages/@birdcc/vscode/test/eligibility-gate.test.ts
@@ -1,0 +1,94 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TextDocument } from "vscode";
+
+const mocks = vi.hoisted(() => ({
+  workspaceRoot: "",
+}));
+
+const disposable = () => ({ dispose: vi.fn() });
+
+vi.mock("vscode", () => ({
+  workspace: {
+    getWorkspaceFolder: () => ({
+      uri: { fsPath: mocks.workspaceRoot },
+    }),
+    createFileSystemWatcher: () => ({
+      ...disposable(),
+      onDidCreate: () => disposable(),
+      onDidChange: () => disposable(),
+      onDidDelete: () => disposable(),
+    }),
+    onDidChangeWorkspaceFolders: () => disposable(),
+    onDidCloseTextDocument: () => disposable(),
+  },
+}));
+
+import { createBirdDocumentEligibilityGate } from "../src/eligibility/gate.js";
+
+const createDocument = (
+  filePath: string,
+  text: string,
+  version: number,
+): TextDocument =>
+  ({
+    uri: {
+      scheme: "file",
+      fsPath: filePath,
+      toString: () => `file://${filePath}`,
+    },
+    version,
+    getText: () => text,
+  }) as unknown as TextDocument;
+
+describe("VS Code BIRD document eligibility gate", () => {
+  beforeEach(async () => {
+    mocks.workspaceRoot = await mkdtemp(join(tmpdir(), "birdcc-vscode-gate-"));
+  });
+
+  afterEach(async () => {
+    await rm(mocks.workspaceRoot, { recursive: true, force: true });
+  });
+
+  it("re-evaluates by URI and document version", async () => {
+    const gate = createBirdDocumentEligibilityGate();
+    const filePath = join(mocks.workspaceRoot, "nginx.conf");
+
+    await expect(
+      gate.isEligible(
+        createDocument(
+          filePath,
+          "events {}\nhttp { server { listen 80; } }",
+          1,
+        ),
+      ),
+    ).resolves.toBe(false);
+    await expect(
+      gate.isEligible(createDocument(filePath, "protocol device {}", 2)),
+    ).resolves.toBe(true);
+
+    gate.dispose();
+  });
+
+  it("accepts canonical and explicitly configured empty documents", async () => {
+    const gate = createBirdDocumentEligibilityGate();
+    const canonicalPath = join(mocks.workspaceRoot, "bird3.conf");
+    const explicitPath = join(mocks.workspaceRoot, "custom.conf");
+    await writeFile(
+      join(mocks.workspaceRoot, "bird.config.json"),
+      JSON.stringify({ main: "custom.conf" }),
+      "utf8",
+    );
+
+    await expect(
+      gate.isEligible(createDocument(canonicalPath, "", 1)),
+    ).resolves.toBe(true);
+    await expect(
+      gate.isEligible(createDocument(explicitPath, "", 1)),
+    ).resolves.toBe(true);
+
+    gate.dispose();
+  });
+});

--- a/packages/@birdcc/vscode/test/fallback-validator.test.ts
+++ b/packages/@birdcc/vscode/test/fallback-validator.test.ts
@@ -331,4 +331,21 @@ describe("fallback validator scheduling", () => {
 
     expect(mocks.showErrorMessage).toHaveBeenCalledTimes(1);
   });
+
+  it("does not execute validation for an ineligible foreign document", async () => {
+    const validator = createFallbackValidator(
+      getConfiguration,
+      {
+        appendLine: vi.fn(),
+        dispose: vi.fn(),
+      } as never,
+      async () => false,
+    );
+    const document = createDocument("/tmp/nginx.conf");
+
+    await validator.validateDocument(document);
+
+    expect(mocks.execFile).not.toHaveBeenCalled();
+    expect(mocks.diagnosticDelete).toHaveBeenCalledWith(document.uri);
+  });
 });

--- a/packages/@birdcc/vscode/test/manifest-menus.test.ts
+++ b/packages/@birdcc/vscode/test/manifest-menus.test.ts
@@ -38,4 +38,28 @@ describe("extension manifest menus", () => {
       "onCommand:bird2-lsp.formatActiveDocument",
     );
   });
+
+  it("preserves broad .conf language association and activation", async () => {
+    const manifest = await readExtensionManifest();
+    const activationEvents = (manifest.activationEvents as string[]) ?? [];
+    const contributes = manifest.contributes as
+      | {
+          languages?: Array<{
+            id?: string;
+            extensions?: string[];
+            filenames?: string[];
+          }>;
+        }
+      | undefined;
+    const birdLanguage = contributes?.languages?.find(
+      (language) => language.id === "bird2",
+    );
+
+    expect(birdLanguage?.extensions).toContain(".conf");
+    expect(birdLanguage?.filenames).toEqual(
+      expect.arrayContaining(["bird.conf", "bird2.conf"]),
+    );
+    expect(activationEvents).toContain("onLanguage:bird2");
+    expect(activationEvents).toContain("workspaceContains:**/*.conf");
+  });
 });


### PR DESCRIPTION
## Summary

- qualify BIRD project candidates with parsed top-level language evidence while preserving canonical filenames and explicit main configuration
- resolve relative and glob includes into a deterministic reachable graph before entry ranking
- gate CLI, LSP, and VS Code consumers so foreign or ambiguous configuration files are never selected, analyzed, validated, or formatted automatically
- preserve the existing VS Code .conf association and activation contract

## Verification

- pnpm format
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm --filter @birdcc/vscode test:e2e
- pnpm changeset:status

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bird-chinese-community/codesmith/BIRD-LSP/pr/147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->