### PR TITLE
fix(release): Keep version PRs CI-clean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,10 +59,10 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: pnpm changeset version
+          version: pnpm changeset:version
           publish: pnpm run release:publish
           title: "chore(release): version packages"
-          commit: "chore(release): version packages"
+          commit: "chore(release): Version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "format": "turbo run format",
     "coverage": "turbo run coverage",
     "changeset": "changeset",
-    "changeset:version": "changeset version",
+    "changeset:version": "node tools/version-packages.mjs",
     "changeset:status": "changeset status",
     "release:publish": "pnpm build && changeset publish",
     "release:npm": "node tools/publish-npm-packages.mjs",

--- a/tools/version-packages.mjs
+++ b/tools/version-packages.mjs
@@ -1,0 +1,50 @@
+import { spawnSync } from "node:child_process";
+
+const run = (command, args, options = {}) => {
+  const result = spawnSync(command, args, {
+    stdio: "inherit",
+    ...options,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+};
+
+const packageManager = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+
+run(packageManager, ["exec", "changeset", "version"]);
+run(packageManager, ["install", "--lockfile-only"]);
+
+const changedFiles = spawnSync(
+  "git",
+  [
+    "ls-files",
+    "--modified",
+    "--others",
+    "--exclude-standard",
+    "--",
+    "packages",
+  ],
+  { encoding: "utf8" },
+);
+
+if (changedFiles.error) {
+  throw changedFiles.error;
+}
+
+if (changedFiles.status !== 0) {
+  process.exit(changedFiles.status ?? 1);
+}
+
+const changedChangelogs = changedFiles.stdout
+  .split("\n")
+  .filter((file) => file.endsWith("/CHANGELOG.md"));
+
+if (changedChangelogs.length > 0) {
+  run(packageManager, ["exec", "oxfmt", ...changedChangelogs]);
+}


### PR DESCRIPTION
## Summary

- run Changesets versioning through a dedicated cross-platform script
- refresh `pnpm-lock.yaml` after package versions and internal workspace ranges change
- format only changelogs created or modified by Changesets
- use a sentence-case release commit subject accepted by commitlint

## Root cause

The generated release branch had three independent CI conflicts:

1. `changeset version` updated package manifests without refreshing `pnpm-lock.yaml`, so frozen installs rejected internal dependency version mismatches.
2. generated parser changelog Markdown was rewritten by `build:grammar`'s formatter, tripping the tracked-file drift check.
3. the configured release commit subject used lowercase after the Conventional Commit prefix, while this repository requires sentence case.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm changeset:version` in an isolated detached worktree with the pending changesets
- a second `pnpm install --frozen-lockfile` after versioning
- parser `build:grammar` leaves the formatted generated changelog unchanged
- release commit subject passes commitlint
- `oxfmt`, `oxlint`, and Node syntax checks for the new script
- push hook: `turbo test (quick)`