### PR TITLE
fix(ci): Pass npm token to Changesets action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,7 @@ jobs:
           commit: "chore(release): Version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
 


### PR DESCRIPTION
## Summary

- expose the npm publishing secret as `NPM_TOKEN` for `changesets/action@v1`
- retain `NODE_AUTH_TOKEN` for the npmrc generated by `actions/setup-node`
- keep npm provenance enabled

## Root cause

The release run after #149 logged `No NPM_TOKEN found` and selected npm trusted publishing even though `NODE_AUTH_TOKEN` was set. The `@birdcc/*` packages are not configured for that OIDC trust path, so all first-time publishes failed with E404.

## Validation

- `pnpm exec oxfmt --check .github/workflows/release.yml`
- `pnpm exec prek run --files .github/workflows/release.yml`
- `pnpm test:quick`
- normal pre-push hooks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bird-chinese-community/codesmith/BIRD-LSP/pr/151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->