### PR TITLE
fix(ci): Run releases on GitHub-hosted runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     name: Release
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

- run the Release job on GitHub-hosted Ubuntu 24.04
- preserve npm provenance and the existing release checks

## Root cause

After restoring a valid `NPM_TOKEN`, npm accepted authentication but rejected every package with E422 because Blacksmith is a self-hosted runner and npm provenance only supports GitHub-hosted runners.

## Validation

- `pnpm exec oxfmt --check .github/workflows/release.yml`
- `pnpm exec prek run --files .github/workflows/release.yml`
- `pnpm test:quick`
- normal commit and pre-push hooks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bird-chinese-community/codesmith/BIRD-LSP/pr/152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->