### PR TITLE
ci(release): Use npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,9 +65,6 @@ jobs:
           commit: "chore(release): Version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "true"
 
       # After npm publish, build and upload VSIX artifacts to GitHub Release
       - name: Package VSIX extensions


### PR DESCRIPTION
## Summary

- remove long-lived npm token injection from the release job
- let `changesets/action` authenticate through npm Trusted Publishing and GitHub OIDC
- rely on npm automatic provenance generation for trusted publishes

## Registry configuration

Trusted Publisher relationships were configured and verified for:

- `@birdcc/cli`
- `@birdcc/core`
- `@birdcc/dprint-plugin-bird`
- `@birdcc/formatter`
- `@birdcc/linter`
- `@birdcc/lsp`
- `@birdcc/parser`

Each package is restricted to `bird-chinese-community/BIRD-LSP`, workflow `release.yml`, and `npm publish` permission.

## Validation

- `npm@11.18.0 trust list <package> --json` for all seven packages
- `pnpm exec oxfmt --check .github/workflows/release.yml`
- `pnpm exec prek run --files .github/workflows/release.yml`
- `pnpm test:quick`
- normal commit and pre-push hooks

The existing repository secret is retained as an inactive rollback credential until a real OIDC-backed package publish succeeds.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bird-chinese-community/codesmith/BIRD-LSP/pr/153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->